### PR TITLE
Bozja Buddy v0.2.0.0

### DIFF
--- a/BozjaBuddy/BozjaBuddy.csproj
+++ b/BozjaBuddy/BozjaBuddy.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>0.1.0.3</Version>
+    <Version>0.2.0.0</Version>
     <Description>A sample plugin.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/goatcorp/SamplePlugin</PackageProjectUrl>
@@ -125,6 +125,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="db\audio\epicsaxguy.mp3">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="db\alarm.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/BozjaBuddy/BozjaBuddy.csproj
+++ b/BozjaBuddy/BozjaBuddy.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>0.1.0.2</Version>
+    <Version>0.1.0.3</Version>
     <Description>A sample plugin.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/goatcorp/SamplePlugin</PackageProjectUrl>
@@ -46,16 +46,16 @@
 		  <Link>x64\%(RecursiveDir)\%(Filename)%(Extension)</Link>
 	  </Content>
 	  <Content Include="..\Data\sqlite3.dll">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	  <Content Include="..\Data\System.Data.SQLite.dll">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	  <Content Include="..\Data\System.Data.SQLite.EF6.dll">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	  <Content Include="..\Data\System.Data.SQLite.Linq.dll">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </Content>
 	  <Content Include="..\Data\FFXIVWeather.dll">
 		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/BozjaBuddy/BozjaBuddy.json
+++ b/BozjaBuddy/BozjaBuddy.json
@@ -2,7 +2,7 @@
     "Author": "K-Cli",
     "Name": "Bozja Buddy",
     "Punchline": "Improve your Bozja sufferring. Maybe.",
-    "Description": "Features:\n• Info about Lost Actions, Fragments, FATEs/CE e.g. location, drops, fate chains, mettle rewards, exp rewards, etc.",
+    "Description": "Features:\n• Info about Lost Actions, Fragments, FATEs/CE e.g. location, drops, fate chains, mettle rewards, exp rewards, etc.\n• Weather forecast.\n• Alarms: Time-based, Weather-based, FATE/CE-based.\n• Filterable loadouts planning, saving, and sharing. Featuring a few recommended DRS loadouts from ABBA.",
     "InternalName": "bozjaBuddy",
     "ApplicableVersion": "any",
     "Tags": [

--- a/BozjaBuddy/Data/Alarm/Alarm.cs
+++ b/BozjaBuddy/Data/Alarm/Alarm.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dalamud.Logging;
+using System;
 using System.Collections.Generic;
 
 namespace BozjaBuddy.Data.Alarm
@@ -6,35 +7,60 @@ namespace BozjaBuddy.Data.Alarm
     public abstract class Alarm
     {
         protected static int _ID_COUNTER = 0;
+        public const string _kJsonid = "a";
+        public virtual string _mJsonId { get; set; } = Alarm._kJsonid;
+        public static int kDurationMin = 10;
+        public static int kDurationMax = 1200;
+        public static int kDefaultDuration = 300;
+        public static int kOffsetMin = 10;
+        public static int kOffsetMax = 1200;
         public static string kReprString = $"Alarm #{Alarm._ID_COUNTER}";
         public static string kToolTip = "This is truly one of the alarm ever.";
+        public static int kRecommendedOffset = 180;
         public int mId { get; set; }
         public string mName;
-        public int mDuration;
+        private int _mDuration;
+        public int mDuration
+        {
+            get => this._mDuration;
+            set { this._mDuration = Alarm.ProcessDuration(value); }
+        }
+        private int _mOffset;
+        public int mOffset
+        {
+            get => this._mOffset;
+            set { this._mOffset = Alarm.ProcessOffset(value); }
+        }
         public DateTime? mTimeOfDeath = null;
         public DateTime? mTriggerTime = null;
         public int? mTriggerInt = null;
+        public string? mTriggerString = null;
         public bool mIsAlive { get; set; }          // if the Alarm is on to-be-checked (TBC) list
         public bool mIsRevivable { get; set; }      // if the Alarm can be brought back to TBC list 
-        public bool mIsAwake { get; set; }          // if the Alarm can be checked while on TBC list 
+        public bool mIsAwake { get; set; } = true;          // if the Alarm can be checked while on TBC list 
+        public bool mHasBeenRevived { get; set; } = true;
 
-        protected Alarm() : this(null, null, Alarm.kReprString)
+        protected Alarm() : this(null, null, Alarm.kReprString, Alarm.kDefaultDuration)
         {
         }
         protected Alarm(DateTime? pTriggerTime, 
                         int? pTriggerInt, 
                         string pName = "", 
-                        int pDuration = 60, 
+                        int pDuration = -1, 
                         bool pIsAlive = true, 
-                        bool pIsRevivable = false)
+                        bool pIsRevivable = false,
+                        string pTriggerString = "",
+                        int pOffset = 0)
         {
             this.mId = Alarm._ID_COUNTER; Alarm._ID_COUNTER += 1;
             this.mTriggerTime = pTriggerTime;
             this.mTriggerInt = pTriggerInt;
             this.mName = pName;
-            this.mDuration = pDuration;
+            this.mDuration = pDuration < 0 ? Alarm.kDefaultDuration : pDuration;
             this.mIsAlive = pIsAlive;
             this.mIsRevivable = pIsRevivable;
+            this.mTriggerString = pTriggerString;
+            this.mOffset = pOffset;
         }
         /// <summary>
         /// Specifically workaround for Generic type init.
@@ -44,40 +70,66 @@ namespace BozjaBuddy.Data.Alarm
         public virtual void Init(DateTime? pTriggerTime,
                                 int? pTriggerInt,
                                 string pName = "",
-                                int pDuration = 60,
+                                int pDuration = -1,
                                 bool pIsAlive = true,
-                                bool pIsRevivable = false)
+                                bool pIsRevivable = false,
+                                string pTriggerString = "",
+                                int pOffset = 0)
         {
             this.mTriggerTime = pTriggerTime;
             this.mTriggerInt = pTriggerInt;
             this.mName = pName;
-            this.mDuration = pDuration;
+            this.mDuration = pDuration < 0 ? Alarm.kDefaultDuration : pDuration;
             this.mIsAlive = pIsAlive;
             this.mIsRevivable = pIsRevivable;
+            this.mTriggerString = pTriggerString;
+            this.mOffset = pOffset;
         }
 
         /// <summary>
         /// Check if the given DateTime has passed this alarm's DateTime and still within the threshold.
         /// <para>Is also used for revive checking. If this return false, then the alarm will be revived.</para>
         /// </summary>
-        public abstract bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<int>> pListeners, int pThresholdSeconds = 10);
+        public abstract bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<MsgAlarm>> pListeners, int pThresholdSeconds = 10, bool pFlagRevival = false, Plugin? pPlugin = null);
         public virtual void Kill()
         {
-            this.mTimeOfDeath = DateTime.Now;
+            if (this.mIsAlive) this.mTimeOfDeath = DateTime.Now;
             this.mIsAlive = false;
         }
-        public virtual void Revive(DateTime pCurrTime, Dictionary<string, List<int>> pListeners)
+        public virtual void Revive(DateTime pCurrTime, Dictionary<string, List<MsgAlarm>> pListeners, Plugin? pPlugin = null)
         {
-            if (!this.CheckAlarm(pCurrTime, pListeners))
+            PluginLog.LogDebug("Trying to revive alarm...");
+            if (!this.CheckAlarm(pCurrTime, pListeners, pFlagRevival:true, pPlugin: pPlugin))
             {
+                PluginLog.LogDebug("Revive succeeds!");
                 this.mIsAlive = true;
+                this.mHasBeenRevived = true;
             }
-        }
-        public virtual void SetAwake(bool pIsAwake)
-        {
-            this.mIsAwake = pIsAwake;
         }
 
         public abstract string Serialize();
+
+        public static int GetIdCounter()
+        {
+            return Alarm._ID_COUNTER;
+        }
+        /// <summary>Check if offset is within range. If true, return the original. If not, return the correct one.</summary>
+        public static int ProcessOffset(int pOffset)
+        {
+            if (pOffset < Alarm.kOffsetMin) return Alarm.kOffsetMin;
+            if (pOffset > Alarm.kOffsetMax) return Alarm.kOffsetMax;
+            return pOffset;
+        }
+        /// <summary>Check if duration is within range. If true, return the original. If not, return the correct one.</summary>
+        public static int ProcessDuration(int pOffset)
+        {
+            if (pOffset < Alarm.kDurationMin) return Alarm.kDurationMin;
+            if (pOffset > Alarm.kDurationMax) return Alarm.kDurationMax;
+            return pOffset;
+        }
+        public static void UpdateIdIfGreater(int pNewId)
+        {
+            Alarm._ID_COUNTER = pNewId > Alarm._ID_COUNTER ? pNewId : Alarm._ID_COUNTER;
+        }
     }
 }

--- a/BozjaBuddy/Data/Alarm/Alarm.cs
+++ b/BozjaBuddy/Data/Alarm/Alarm.cs
@@ -1,50 +1,83 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace BozjaBuddy.Data.Alarm
 {
-    public class Alarm
+    public abstract class Alarm
     {
         protected static int _ID_COUNTER = 0;
+        public static string kReprString = $"Alarm #{Alarm._ID_COUNTER}";
+        public static string kToolTip = "This is truly one of the alarm ever.";
         public int mId { get; set; }
-        public string mName { get; set; } = "";
-        protected virtual DateTime mTrigger { get; set; }
-        protected bool mIsAlive { get; set; } = true;
+        public string mName;
+        public int mDuration;
+        public DateTime? mTimeOfDeath = null;
+        public DateTime? mTriggerTime = null;
+        public int? mTriggerInt = null;
+        public bool mIsAlive { get; set; }          // if the Alarm is on to-be-checked (TBC) list
+        public bool mIsRevivable { get; set; }      // if the Alarm can be brought back to TBC list 
+        public bool mIsAwake { get; set; }          // if the Alarm can be checked while on TBC list 
 
-        protected Alarm() { }
-
-        public Alarm(DateTime pTrigger)
+        protected Alarm() : this(null, null, Alarm.kReprString)
         {
-            this.mId = _ID_COUNTER; Alarm._ID_COUNTER += 1;
-            this.mName = $"Alarm #{this.mId}";
-            this.mTrigger = pTrigger;
         }
-        public Alarm(DateTime pTrigger, string pName)
+        protected Alarm(DateTime? pTriggerTime, 
+                        int? pTriggerInt, 
+                        string pName = "", 
+                        int pDuration = 60, 
+                        bool pIsAlive = true, 
+                        bool pIsRevivable = false)
         {
-            this.mId = _ID_COUNTER; Alarm._ID_COUNTER += 1;
+            this.mId = Alarm._ID_COUNTER; Alarm._ID_COUNTER += 1;
+            this.mTriggerTime = pTriggerTime;
+            this.mTriggerInt = pTriggerInt;
             this.mName = pName;
-            this.mTrigger = pTrigger;
+            this.mDuration = pDuration;
+            this.mIsAlive = pIsAlive;
+            this.mIsRevivable = pIsRevivable;
+        }
+        /// <summary>
+        /// Specifically workaround for Generic type init.
+        /// Use default contructor first, then init data with this.
+        /// <para>Does not increment _ID_COUNTER</para>
+        /// </summary>
+        public virtual void Init(DateTime? pTriggerTime,
+                                int? pTriggerInt,
+                                string pName = "",
+                                int pDuration = 60,
+                                bool pIsAlive = true,
+                                bool pIsRevivable = false)
+        {
+            this.mTriggerTime = pTriggerTime;
+            this.mTriggerInt = pTriggerInt;
+            this.mName = pName;
+            this.mDuration = pDuration;
+            this.mIsAlive = pIsAlive;
+            this.mIsRevivable = pIsRevivable;
         }
 
         /// <summary>
         /// Check if the given DateTime has passed this alarm's DateTime and still within the threshold.
+        /// <para>Is also used for revive checking. If this return false, then the alarm will be revived.</para>
         /// </summary>
-        /// <param name="pCurrTime"></param>
-        /// <param name="pThresholdSeconds"></param>
-        /// <returns></returns>
-        public virtual bool CheckAlarm(Plugin pPlugin)
+        public abstract bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<int>> pListeners, int pThresholdSeconds = 10);
+        public virtual void Kill()
         {
-            if (!this.mIsAlive) { return false; }
-            //double tDelta = (pCurrTime - this.mTrigger).TotalSeconds;
-            //if (tDelta > 0 && tDelta < pThresholdSeconds)
-            //    return true;
-            //else
-            //    return false;
-            return true;
+            this.mTimeOfDeath = DateTime.Now;
+            this.mIsAlive = false;
+        }
+        public virtual void Revive(DateTime pCurrTime, Dictionary<string, List<int>> pListeners)
+        {
+            if (!this.CheckAlarm(pCurrTime, pListeners))
+            {
+                this.mIsAlive = true;
+            }
+        }
+        public virtual void SetAwake(bool pIsAwake)
+        {
+            this.mIsAwake = pIsAwake;
         }
 
-        public virtual string Serialize() 
-        {
-            return "";
-        }
+        public abstract string Serialize();
     }
 }

--- a/BozjaBuddy/Data/Alarm/AlarmFateCe.cs
+++ b/BozjaBuddy/Data/Alarm/AlarmFateCe.cs
@@ -1,32 +1,92 @@
-﻿using System;
+﻿using Dalamud.Logging;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BozjaBuddy.Data.Alarm
 {
     internal class AlarmFateCe : Alarm
     {
-        public new static string kReprString = $"Alarm #{Alarm._ID_COUNTER} [FATECE]";
+        public new const string _kJsonid = "af";
+        public new static string kReprString = "FateCe";
         public new static string kToolTip = "Alarm for a specific Fate or CE. Can go off once, or every time the FATE or CE comes around.";
+        public override string _mJsonId { get; set; } = AlarmFateCe._kJsonid;
         public AlarmFateCe() : base(null, null, kReprString) { }
-        public AlarmFateCe(DateTime? pTriggerTime, int? pTriggerInt, string? pName = null)
-            : base(pTriggerTime, pTriggerInt, pName ?? kReprString)
+        public AlarmFateCe(DateTime? pTriggerTime, int? pTriggerInt, string? pName = null, string? pTriggerString = null)
+            : base(pTriggerTime, pTriggerInt, pName ?? kReprString, 60, true, false, pTriggerString ?? "")
         {
         }
 
-        public override bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<int>> pListeners, int pThresholdSeconds = 10)
+        public override bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<MsgAlarm>> pListeners, int pThresholdSeconds = 1380, bool pIsReviving = false, Plugin? pPlugin = null)
         {
-            if (!this.mIsAlive || this.mTriggerInt.HasValue)
+            bool tIsInOnceMode = this.mTriggerTime.HasValue && !this.mIsRevivable;
+            PluginLog.LogDebug(String.Format("========== Alarm has isAlive={2} | trgTime={0} | isRevivable={1} | isReviving={3} | hasBeenRezzed={6} | mOffset={4} | isInOnceMode={5}",
+                                            this.mTriggerTime.HasValue ? this.mTriggerTime.ToString() : "null",
+                                            this.mIsRevivable,
+                                            this.mIsAlive,
+                                            pIsReviving,
+                                            this.mOffset,
+                                            tIsInOnceMode,
+                                            this.mHasBeenRevived));
+            // Flags validation
+            if (!pIsReviving
+                && (!this.mIsAlive
+                || !this.mTriggerInt.HasValue))
             {
+                PluginLog.LogDebug($"CHECK FAILED: Alarm is dead (isAlive={this.mIsAlive}) or has no sufficient info (trgInt={this.mTriggerInt.HasValue})!");
+                PluginLog.LogDebug("ALARM KILLED: Alarm killed by flags validation!");
                 this.Kill();
                 return false;
             }
-            if (pListeners["fatece"].Contains(this.mTriggerInt!.Value))
-                return true;
+
+            // Reloading mTriggerTime for repeat-mode (only after init or after being rezzed)
+            if (!tIsInOnceMode && this.mHasBeenRevived)
+            {
+                this.mHasBeenRevived = false;
+            }
+
+            double tDelta = (pCurrTime - this.mTriggerTime!.Value).TotalSeconds;
+            // Check msg
+            if (!this.CheckMsg(pListeners, tDelta, pIsReviving, pPlugin: pPlugin))
+            {
+                return false;
+            }
+
+            if (pIsReviving)
+            {
+                PluginLog.LogDebug($"Revive failed. Either all msg is met, or not out of Offset's range yet (tDelta={tDelta} > tOffset={this.mOffset})");
+            }
             else
             {
+                PluginLog.LogDebug($"ALARM KILLED: Alarm killed by final! (tDelta={tDelta} > tOffset={this.mOffset})");
                 this.Kill();
-                return false;
             }
+            return true;
+        }
+
+        private bool CheckMsg(Dictionary<string, List<MsgAlarm>> pListeners, double tDelta, bool pIsReviving = false, Plugin? pPlugin = null)
+        {
+            if (pPlugin == null) 
+            {
+                PluginLog.LogDebug("CHECK FAILED: No pPlugin given to perform the check.");
+                return false; 
+            }
+            foreach (Dalamud.Game.ClientState.Fates.Fate iFate in pPlugin!.FateTable)
+            {
+                if (this.mTriggerInt == iFate.FateId)
+                {
+                    PluginLog.LogDebug(String.Format("CHECK SUCCEEDED: Alarm's msgAlarm check is true! (trgInt={0} FateId={1})",
+                                    this.mTriggerInt,
+                                    iFate.FateId
+                                ));
+                    return true;
+                }
+            }
+            PluginLog.LogDebug(String.Format("CHECK FAILED: No msg is true. (trgInt={0}) ({1})",
+                                            this.mTriggerInt,
+                                            String.Join(", ", pPlugin!.FateTable.Select(o => o.FateId))
+                                            ));
+            return false;
         }
 
         public override string Serialize()

--- a/BozjaBuddy/Data/Alarm/AlarmFateCe.cs
+++ b/BozjaBuddy/Data/Alarm/AlarmFateCe.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 
 namespace BozjaBuddy.Data.Alarm
 {
-    internal class AlarmWeather : Alarm
+    internal class AlarmFateCe : Alarm
     {
-        public new static string kReprString = $"Alarm #{Alarm._ID_COUNTER} [WEATHER]";
-        public new static string kToolTip = "Alarm for a specific weather. Can go off once, or every time the weather comes around.";
-        public AlarmWeather() : base(null, null, kReprString) { }
-        public AlarmWeather(DateTime? pTriggerTime, int? pTriggerInt, string? pName = null)
+        public new static string kReprString = $"Alarm #{Alarm._ID_COUNTER} [FATECE]";
+        public new static string kToolTip = "Alarm for a specific Fate or CE. Can go off once, or every time the FATE or CE comes around.";
+        public AlarmFateCe() : base(null, null, kReprString) { }
+        public AlarmFateCe(DateTime? pTriggerTime, int? pTriggerInt, string? pName = null)
             : base(pTriggerTime, pTriggerInt, pName ?? kReprString)
         {
         }
@@ -20,7 +20,7 @@ namespace BozjaBuddy.Data.Alarm
                 this.Kill();
                 return false;
             }
-            if (pListeners["weather"].Contains(this.mTriggerInt!.Value))
+            if (pListeners["fatece"].Contains(this.mTriggerInt!.Value))
                 return true;
             else
             {

--- a/BozjaBuddy/Data/Alarm/AlarmManager.cs
+++ b/BozjaBuddy/Data/Alarm/AlarmManager.cs
@@ -1,22 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
+using BozjaBuddy.GUI;
+using BozjaBuddy.GUI.Sections;
 using Dalamud.Logging;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using NAudio.Wave;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace BozjaBuddy.Data.Alarm
 {
     public class AlarmManager : IDisposable
     {
-        public static Dictionary<string, List<int>> Listeners = new Dictionary<string, List<int>>();
-        private List<Alarm> mAlarmList = new List<Alarm>();
-        private List<Alarm> mDisposedAlarmList = new List<Alarm>();
-        private int mDurationLeft = 0;
-        private bool mIsEnabled = false;
+        public static Dictionary<string, List<MsgAlarm>> Listeners = new Dictionary<string, List<MsgAlarm>>();
         private const int INTERVAL = 1000;
+        private List<Alarm> mAlarmList = new List<Alarm>();
+        private List<Alarm> mExpiredAlarmList = new List<Alarm>();
+        private int mDurationLeft = 0;
+        private int mActiveAndAwakeAlarmCount = 0;
+        private bool mIsEnabled = false;
         private bool mIsAppActivated = false;
         private bool mIsAlarmTriggered = false;
         private bool mIsSoundMute = false;
+        private bool mIsAudioFileReloaded = false;
         private Plugin mPlugin;
         private WaveOutEvent? mOutputDevice;
         private LoopStream? mAudioFile;
@@ -24,6 +33,7 @@ namespace BozjaBuddy.Data.Alarm
         public AlarmManager(Plugin pPlugin)
         {
             mPlugin = pPlugin;
+            this.LoadAlarmListsFromDisk();
             mAudioFile = new LoopStream(new AudioFileReader(mPlugin.DATA_PATHS["alarm_audio"]));
             mOutputDevice = new WaveOutEvent();
             mOutputDevice?.Init(mAudioFile);
@@ -36,10 +46,21 @@ namespace BozjaBuddy.Data.Alarm
         {
             this.mIsAlarmTriggered = pStatus;
         }
-        public void MuteSound()
+        public void ReloadAudio()
         {
-            this.mIsSoundMute = true;
+            // Dispose
+            mOutputDevice?.Dispose();
+            mAudioFile?.Dispose();
+
+            // Load
+            mAudioFile = new LoopStream(new AudioFileReader(mPlugin.DATA_PATHS["alarm_audio"]));
+            mOutputDevice = new WaveOutEvent();
+            mOutputDevice?.Init(mAudioFile);
         }
+        public void MuteSound() { this.mIsSoundMute = true; }
+        public void UnmuteSound() { this.mIsSoundMute = false; }
+        public bool GetMuteStatus() => this.mIsSoundMute;
+        public bool GetTriggerStatus() => this.mIsAlarmTriggered;
         public void Start()
         {
             mIsEnabled = true;
@@ -50,14 +71,180 @@ namespace BozjaBuddy.Data.Alarm
         public void AddAlarm(Alarm pAlarm)
         {
             mAlarmList.Add(pAlarm);
+            this.mActiveAndAwakeAlarmCount++;
 
-            // FIXME: add saving to disk
+            // Save to disk
+            this.SaveAlarmListsToDisk();
         }
+        public void RemoveAlarm(int pAlarmId)
+        {
+            // Active alarm
+            Alarm? pTargetAlarm = null;
+            foreach (Alarm iAlarm in this.mAlarmList)
+            {
+                if (iAlarm.mId == pAlarmId)
+                {
+                    pTargetAlarm = iAlarm;
+                    break;
+                }
+            }
+            if (pTargetAlarm != null)
+            {
+                this.mAlarmList.Remove(pTargetAlarm);
+                if (pTargetAlarm.mIsAwake) this.mActiveAndAwakeAlarmCount--;
+                return;
+            }
+            // Expired alarm
+            foreach (Alarm iAlarm in this.mExpiredAlarmList)
+            {
+                if (iAlarm.mId == pAlarmId)
+                {
+                    pTargetAlarm = iAlarm;
+                    break;
+                }
+            }
+            if (pTargetAlarm != null)
+            {
+                this.mExpiredAlarmList.Remove(pTargetAlarm);
+                if (pTargetAlarm.mIsAwake) this.mActiveAndAwakeAlarmCount--;
+                return;
+            }
+
+            // Save to disk
+            this.SaveAlarmListsToDisk();
+        }
+        public void RemoveAlarm(Alarm pAlarm)
+        {
+            if (this.mAlarmList.Remove(pAlarm) && pAlarm.mIsAwake)
+                this.mActiveAndAwakeAlarmCount--;
+            if (this.mExpiredAlarmList.Remove(pAlarm) && pAlarm.mIsAwake)
+                this.mActiveAndAwakeAlarmCount--;
+
+            // Save to disk
+            this.SaveAlarmListsToDisk();
+        }
+        /// <summary> Active alarm only </summary>
+        public void WakeAlarm(int pAlarmId)
+        {
+            // Active alarm
+            foreach (Alarm iAlarm in this.mAlarmList)
+            {
+                if (iAlarm.mId == pAlarmId)
+                {
+                    if (!iAlarm.mIsAwake)
+                    {
+                        iAlarm.mIsAwake = true;
+                        this.mActiveAndAwakeAlarmCount++;
+                    }
+                    break;
+                }
+            }
+        }
+        public void WakeAlarm(Alarm pAlarm)
+        {
+            if (!pAlarm.mIsAwake)
+            {
+                pAlarm.mIsAwake = true;
+                this.mActiveAndAwakeAlarmCount++;
+            }
+        }
+        /// <summary> Active alarm only </summary>
+        public void SleepAlarm(int pAlarmId)
+        {
+            // Active alarm
+            foreach (Alarm iAlarm in this.mAlarmList)
+            {
+                if (iAlarm.mId == pAlarmId)
+                {
+                    if (iAlarm.mIsAwake)
+                    {
+                        iAlarm.mIsAwake = false;
+                        this.mActiveAndAwakeAlarmCount--;
+                    }
+                    break;
+                }
+            }
+        }
+        public void SleepAlarm(Alarm pAlarm)
+        {
+            if (pAlarm.mIsAwake)
+            {
+                pAlarm.mIsAwake = false;
+                this.mActiveAndAwakeAlarmCount--;
+            }
+        }
+        public void ExpireAlarm(Alarm pAlarm)
+        {
+            this.mExpiredAlarmList.Add(pAlarm);
+            this.mAlarmList.Remove(pAlarm);
+            this.mActiveAndAwakeAlarmCount -= 1;
+        }
+        public void UnexpireAlarm(Alarm pAlarm)
+        {
+            pAlarm.mIsAlive = true;
+            this.mAlarmList.Add(pAlarm);
+            this.mExpiredAlarmList.Remove(pAlarm);
+            this.mActiveAndAwakeAlarmCount += 1;
+        }
+        private void SaveAlarmListsToDisk()
+        {
+            List<List<Alarm>> tAlarmLists = new List<List<Alarm>> { this.mAlarmList, this.mExpiredAlarmList };
+            string tJson = JsonConvert.SerializeObject(tAlarmLists);
+            PluginLog.LogDebug($">>> SAVING TO DISK: {tJson}");
+            File.WriteAllText(this.mPlugin.DATA_PATHS["alarm.json"], tJson);
+        }
+        private void LoadAlarmListsFromDisk()
+        {
+            JsonConverter[] tConverters = { new AlarmConverter() };
+            List<List<Alarm>>? tAlarmLists = JsonConvert.DeserializeObject<List<List<Alarm>>>(
+                        File.ReadAllText(this.mPlugin.DATA_PATHS["alarm.json"]),
+                        tConverters
+                    );
+            if (tAlarmLists == null)
+            {
+                PluginLog.LogDebug(">>> A_MNG: Unable to load alarm from disk.");
+                return;
+            }
+            this.mAlarmList = tAlarmLists![0];
+            this.mExpiredAlarmList = tAlarmLists![1];
+            // Update id count
+            foreach (Alarm iAlarm in this.mAlarmList)
+            {
+                Alarm.UpdateIdIfGreater(iAlarm.mId);
+            }
+            foreach (Alarm iAlarm in this.mExpiredAlarmList)
+            {
+                Alarm.UpdateIdIfGreater(iAlarm.mId);
+            }
+            this.RefreshAAAAlarmCount();
+        }
+        private void RefreshAAAAlarmCount()
+        {
+            // Recalculated mActiveAndAwakeAlarmCount
+            foreach (Alarm iAlarm in this.mAlarmList)
+            {
+                if (iAlarm.mIsAwake) { this.mActiveAndAwakeAlarmCount++; }
+            }
+        }
+        public int GetAAAAlarmCount() => this.mActiveAndAwakeAlarmCount;
+        public List<Alarm> GetAlarms() => this.mAlarmList;
+        public List<Alarm> GetDisposedAlarms() => this.mExpiredAlarmList;
+        public int GetDurationLeft() => this.mDurationLeft;
 
         private void MyAlarm()
         {
+            int tCounter = 0;
             while (mIsEnabled)
             {
+                if (this.mActiveAndAwakeAlarmCount == 0 && !(this.mDurationLeft > 0))
+                {
+                    Thread.Sleep(INTERVAL);
+                    continue;
+                }
+
+                if (tCounter % 5 == 0) // refresh every 5 secs
+                    WeatherBarSection._updateWeatherCurr(mPlugin);
+                tCounter = tCounter == 5 ? 0 : tCounter + 1;
                 //if (Native.ApplicationIsActivated() && !mIsAppActivated)
                 //{
                 //    mIsAppActivated = true;
@@ -70,26 +257,36 @@ namespace BozjaBuddy.Data.Alarm
                 //    //this.mIsAlarmTriggered = false;
                 //    PluginLog.Information("App stops being focused.");
                 //}
-
+                List<Alarm> tTempAlarmBin = new List<Alarm>();
                 foreach (Alarm iAlarm in this.mAlarmList)
                 {
-                    if (iAlarm.CheckAlarm(DateTime.Now, AlarmManager.Listeners))
+                    if (!iAlarm.mIsAwake) continue;
+                    // check if alarm should be killed. If yes, refresh the duration => trigger the sound player
+                    if (iAlarm.CheckAlarm(DateTime.Now, AlarmManager.Listeners, pPlugin: this.mPlugin))
                     {
                         this.mDurationLeft = iAlarm.mDuration;
+                        PluginLog.LogDebug($"========== A_MNG: Refreshing duration (duration={iAlarm.mDuration})");
                     }
-                    else if (iAlarm.mTimeOfDeath.HasValue && (DateTime.Now - iAlarm.mTimeOfDeath!.Value).TotalSeconds > iAlarm.mDuration)      // x amount of seconds after alarm is dead
+                    // alarm is dead. Check if the grace period is finished. Revive if possible, else throw to the bin.
+                    else if (!iAlarm.mIsAlive && iAlarm.mTimeOfDeath.HasValue && (DateTime.Now - iAlarm.mTimeOfDeath!.Value).TotalSeconds > iAlarm.mDuration)      // x amount of seconds after alarm is dead
                     {
+                        PluginLog.LogDebug($"ALARM's has timeOfDeath? {iAlarm.mTimeOfDeath.HasValue} ({iAlarm.mTimeOfDeath})");
                         if (iAlarm.mIsRevivable)
                         {
-                            iAlarm.Revive(DateTime.Now, AlarmManager.Listeners);
+                            iAlarm.Revive(DateTime.Now, AlarmManager.Listeners, pPlugin: this.mPlugin);
                         }
                         else
                         {
-                            this.mDisposedAlarmList.Add(iAlarm);
-                            this.mAlarmList.Remove(iAlarm);
+                            tTempAlarmBin.Add(iAlarm);
                         }
                     }
+                    PluginLog.Debug($">>> A_MNG: tOD={iAlarm.mTimeOfDeath?.ToString()} timeSinceDeath={(iAlarm.mTimeOfDeath.HasValue ? (DateTime.Now - iAlarm.mTimeOfDeath!.Value).TotalSeconds : 0)} mDuration={iAlarm.mDuration}");
                 }
+                foreach (Alarm iAlarm in tTempAlarmBin)
+                {
+                    this.ExpireAlarm(iAlarm);
+                }
+
                 if (this.mDurationLeft > 0)
                 {
                     this.mIsAlarmTriggered = true;
@@ -98,24 +295,48 @@ namespace BozjaBuddy.Data.Alarm
                 else
                 {
                     this.mIsAlarmTriggered = false;
+                    this.UnmuteSound();
                 }
 
+                // Audio stuff
                 try
                 {
-                    if (mIsAlarmTriggered)
+                    if (this.mIsAudioFileReloaded)
                     {
-                        if (!this.mIsSoundMute && mOutputDevice != null && mOutputDevice.PlaybackState == PlaybackState.Stopped)
+                        this.mIsAudioFileReloaded = false;
+                        this.mIsSoundMute = true;
+                        this.mOutputDevice!.Stop();
+                        this.mOutputDevice!.Dispose();
+                        this.mOutputDevice = null;
+                        this.mAudioFile?.Dispose();
+                        this.mAudioFile = null;
+                    }
+                    if (this.mIsAlarmTriggered && !this.mIsSoundMute)
+                    {
+                        if (this.mOutputDevice == null || this.mAudioFile == null)
+                        {
+                            this.mOutputDevice?.Dispose();
+                            this.mAudioFile?.Dispose();
+                            this.mAudioFile = new LoopStream(new AudioFileReader(mPlugin.DATA_PATHS["alarm_audio"]));
+                            this.mOutputDevice = new WaveOutEvent();
+                            this.mOutputDevice?.Init(this.mAudioFile);
+                        }
+                        if (!this.mIsSoundMute && this.mOutputDevice != null && this.mOutputDevice.PlaybackState == PlaybackState.Stopped)
                         {
                             PluginLog.Information("Alarm sound playing.");
-                            mOutputDevice!.Play();
+                            this.mOutputDevice!.Play();
                         }
                     }
                     else
                     {
-                        if (mOutputDevice != null && mOutputDevice.PlaybackState == PlaybackState.Playing)
+                        if (this.mOutputDevice != null && this.mOutputDevice.PlaybackState == PlaybackState.Playing)
                         {
                             PluginLog.Information("Alarm sound stopped.");
-                            mOutputDevice!.Stop();
+                            this.mOutputDevice!.Stop();
+                            this.mOutputDevice!.Dispose();
+                            this.mOutputDevice = null;
+                            this.mAudioFile?.Dispose();
+                            this.mAudioFile = null;
                         }
 
                     }
@@ -207,6 +428,38 @@ namespace BozjaBuddy.Data.Alarm
                 totalBytesRead += bytesRead;
             }
             return totalBytesRead;
+        }
+    }
+
+    // https://blog.codeinside.eu/2015/03/30/json-dotnet-deserialize-to-abstract-class-or-interface/
+    public class AlarmConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(Alarm));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            JObject jo = JObject.Load(reader);
+            if (jo["_mJsonId"]!.Value<string>() == AlarmWeather._kJsonid)
+                return jo.ToObject<AlarmWeather>(serializer)!;
+            else if (jo["_mJsonId"]!.Value<string>() == AlarmTime._kJsonid)
+                return jo.ToObject<AlarmTime>(serializer)!;
+            else if (jo["_mJsonId"]!.Value<string>() == AlarmFateCe._kJsonid)
+                return jo.ToObject<AlarmFateCe>(serializer)!;
+            else
+                return jo.ToObject<Alarm>(serializer)!;
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/BozjaBuddy/Data/Alarm/AlarmTime.cs
+++ b/BozjaBuddy/Data/Alarm/AlarmTime.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace BozjaBuddy.Data.Alarm
+{
+    public class AlarmTime : Alarm
+    {
+        public new static string kReprString = $"Alarm #{Alarm._ID_COUNTER} [TIME]";
+        public new static string kToolTip = "Alarm for a specific time. Can only go off once.";
+        public AlarmTime() : base(null, null, kReprString) { }
+        public AlarmTime(DateTime? pTriggerTime, int? pTriggerInt, string? pName = null)
+            : base(pTriggerTime, pTriggerInt, pName ?? kReprString)
+        {
+        }
+
+        public override bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<int>> pListeners, int pThresholdSeconds = 60)
+        {
+            if (!this.mIsAlive || this.mTriggerTime.HasValue)
+            {
+                this.Kill();
+                return false;
+            }
+            double tDelta = (pCurrTime - this.mTriggerTime!.Value).TotalSeconds;
+            if (tDelta > 0 && tDelta < pThresholdSeconds)
+                return true;
+            else
+            {
+                this.Kill();
+                return false;
+            }
+        }
+        public override void Revive(DateTime pCurrTime, Dictionary<string, List<int>> pListeners)
+        {
+            this.mIsRevivable = false;  // Time-based alarm should not be revived. Disable the flag just in case.
+        }
+
+        public override string Serialize() 
+        {
+            return "";
+        }
+    }
+}

--- a/BozjaBuddy/Data/Alarm/AlarmTime.cs
+++ b/BozjaBuddy/Data/Alarm/AlarmTime.cs
@@ -1,35 +1,69 @@
-﻿using System;
+﻿using Dalamud.Logging;
+using System;
 using System.Collections.Generic;
 
 namespace BozjaBuddy.Data.Alarm
 {
     public class AlarmTime : Alarm
     {
-        public new static string kReprString = $"Alarm #{Alarm._ID_COUNTER} [TIME]";
+        public new const string _kJsonid  = "at";
+        public new static string kReprString = "Time";
         public new static string kToolTip = "Alarm for a specific time. Can only go off once.";
+        public override string _mJsonId { get; set; } = AlarmTime._kJsonid;
         public AlarmTime() : base(null, null, kReprString) { }
         public AlarmTime(DateTime? pTriggerTime, int? pTriggerInt, string? pName = null)
             : base(pTriggerTime, pTriggerInt, pName ?? kReprString)
         {
+            this.mIsRevivable = false;
+        }
+        public override void Init(DateTime? pTriggerTime, int? pTriggerInt, string pName = "", int pDuration = -1, bool pIsAlive = true, bool pIsRevivable = false, string pTriggerString = "", int pOffset = 0)
+        {
+            base.Init(pTriggerTime, pTriggerInt, pName, pDuration, pIsAlive, false, pTriggerString, pOffset);
         }
 
-        public override bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<int>> pListeners, int pThresholdSeconds = 60)
+        public override bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<MsgAlarm>> pListeners, int pThresholdSeconds = 60, bool pIsReviving = false, Plugin? pPlugin = null)
         {
-            if (!this.mIsAlive || this.mTriggerTime.HasValue)
+            PluginLog.LogDebug(String.Format("========== ATime has isAlive={2} | trgTime={0} | isRevivable={1} | isReviving={3} | hasBeenRezzed={6} | mOffset={4} | isInOnceMode={5}",
+                                            this.mTriggerTime.HasValue ? this.mTriggerTime.ToString() : "null",
+                                            this.mIsRevivable,
+                                            this.mIsAlive,
+                                            pIsReviving,
+                                            this.mOffset,
+                                            false,
+                                            this.mHasBeenRevived));
+            // Flags validation
+            if (!this.mIsAlive || !this.mTriggerTime.HasValue)
             {
+                PluginLog.LogDebug($"CHECK FAILED: Alarm is dead (isAlive={this.mIsAlive}) or not enough info (mTriggerTime={this.mTriggerTime.HasValue})!");
+                PluginLog.LogDebug("ALARM KILLED: Alarm killed by flags validation!");
                 this.Kill();
                 return false;
             }
+
             double tDelta = (pCurrTime - this.mTriggerTime!.Value).TotalSeconds;
-            if (tDelta > 0 && tDelta < pThresholdSeconds)
-                return true;
-            else
+            // Check if current time has reached, or already past mTriggerTime for an amount of mOffset seconds
+            if (Math.Abs(tDelta) > this.mOffset)
             {
-                this.Kill();
-                return false;
+                if (tDelta < 0)
+                {
+                    PluginLog.LogDebug("CHECK FAILED: Time has not reached");
+                    return false;
+                }
+                else if (tDelta > 0)
+                {
+                    PluginLog.LogDebug("CHECK FAILED: Time has already gone past the threshold");
+                    PluginLog.LogDebug("ALARM KILLED: Alarm killed by trgTime!");
+                    this.Kill();
+                    return false;
+                }
             }
+
+            PluginLog.LogDebug($"ALARM KILLED: Alarm killed by final! (tDelta={tDelta} > tOffset={this.mOffset})");
+            this.Kill();
+
+            return true;
         }
-        public override void Revive(DateTime pCurrTime, Dictionary<string, List<int>> pListeners)
+        public override void Revive(DateTime pCurrTime, Dictionary<string, List<MsgAlarm>> pListeners, Plugin? pPlugin = null)
         {
             this.mIsRevivable = false;  // Time-based alarm should not be revived. Disable the flag just in case.
         }

--- a/BozjaBuddy/Data/Alarm/AlarmWeather.cs
+++ b/BozjaBuddy/Data/Alarm/AlarmWeather.cs
@@ -1,32 +1,136 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using BozjaBuddy.GUI.Sections;
+using Dalamud.Logging;
 
 namespace BozjaBuddy.Data.Alarm
 {
     internal class AlarmWeather : Alarm
     {
-        public new static string kReprString = $"Alarm #{Alarm._ID_COUNTER} [WEATHER]";
-        public new static string kToolTip = "Alarm for a specific weather. Can go off once, or every time the weather comes around.";
+        public new const string _kJsonid  = "aw";
+        public new static string kReprString = "Weather";
+        public new static string kToolTip = "Alarm for weather of a specific zone.\n- ONCE: The alarm can only be triggered by the chosen weather at that specific time.\n- REPEAT: The alarm can be triggered every time the chosen type of weather occurs.";
+        public override string _mJsonId { get; set; } = AlarmWeather._kJsonid;
+        private int mMsgCheckCounter = 0; // check thrice, due to channel swtiching shenaningans and currWeather changing
         public AlarmWeather() : base(null, null, kReprString) { }
-        public AlarmWeather(DateTime? pTriggerTime, int? pTriggerInt, string? pName = null)
-            : base(pTriggerTime, pTriggerInt, pName ?? kReprString)
+        public AlarmWeather(DateTime? pTriggerTime, int? pTriggerWeatherId, string? pName = null, string? pTriggerTerritoryId = null, int pOffset = 0)
+            : base(pTriggerTime, pTriggerWeatherId, pName ?? kReprString, 60, true, false, pTriggerTerritoryId ?? "", pOffset)
         {
         }
 
-        public override bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<int>> pListeners, int pThresholdSeconds = 10)
+        public override bool CheckAlarm(DateTime pCurrTime, Dictionary<string, List<MsgAlarm>> pListeners, int pThresholdSeconds = 1380, bool pIsReviving = false, Plugin? pPlugin = null)
         {
-            if (!this.mIsAlive || this.mTriggerInt.HasValue)
+            bool tIsInOnceMode = this.mTriggerTime.HasValue && !this.mIsRevivable;
+            PluginLog.LogDebug(String.Format("========== Alarm has isAlive={2} | trgTime={0} | isRevivable={1} | isReviving={3} | hasBeenRezzed={6} | mOffset={4} | isInOnceMode={5}",
+                                            this.mTriggerTime.HasValue ? this.mTriggerTime.ToString() : "null",
+                                            this.mIsRevivable,
+                                            this.mIsAlive,
+                                            pIsReviving,
+                                            this.mOffset,
+                                            tIsInOnceMode,
+                                            this.mHasBeenRevived));
+            // Flags validation
+            if (!pIsReviving
+                && (!this.mIsAlive 
+                || !this.mTriggerInt.HasValue 
+                || this.mTriggerString == ""))
             {
+                PluginLog.LogDebug($"CHECK FAILED: Alarm is dead (isAlive={this.mIsAlive}) or has no sufficient info (trgInt={this.mTriggerInt.HasValue} trgStr={this.mTriggerString})!");
+                PluginLog.LogDebug("ALARM KILLED: Alarm killed by flags validation!");
                 this.Kill();
                 return false;
             }
-            if (pListeners["weather"].Contains(this.mTriggerInt!.Value))
-                return true;
+
+            // Reloading mTriggerTime for repeat-mode (only after init or after being rezzed)
+            if (!tIsInOnceMode && this.mHasBeenRevived)
+            {
+                this.mHasBeenRevived = false;
+                this.ReloadTriggerTime();
+            }
+
+            double tDelta = (pCurrTime - this.mTriggerTime!.Value).TotalSeconds;
+            // Check msg
+            if (!this.CheckMsg(pListeners, tDelta, pIsReviving))
+            {
+                return false;
+            }
+            // Check if current time has reached, or already past mTriggerTime for an amount of mOffset seconds
+            if (Math.Abs(tDelta) > this.mOffset)
+            {
+                if (tDelta < 0)
+                {
+                    PluginLog.LogDebug("CHECK FAILED: Time has not reached");
+                    return false;
+                }
+                else if (tDelta > 0)
+                {
+                    PluginLog.LogDebug("CHECK FAILED: Time has already gone past the threshold");
+                    PluginLog.LogDebug("ALARM KILLED: Alarm killed by trgTime!");
+                    this.Kill();
+                    return false;
+                }
+            }
+
+            if (pIsReviving)
+            {
+                PluginLog.LogDebug($"Revive failed. Either all msg is met, or not out of Offset's range yet (tDelta={tDelta} > tOffset={this.mOffset})");
+            }
             else
             {
+                PluginLog.LogDebug($"ALARM KILLED: Alarm killed by final! (tDelta={tDelta} > tOffset={this.mOffset})");
                 this.Kill();
-                return false;
             }
+            return true;
+        }
+
+        private void ReloadTriggerTime()
+        {
+            PluginLog.LogDebug("ALARM RELOADED!");
+            if (this.mTriggerString != "") 
+                this.mTriggerTime = Utils.Utils.ProcessToLocalTime(WeatherBarSection.GetWeatherNext(null, this.mTriggerString!, false).Item2);
+        }
+        private bool CheckMsg(Dictionary<string, List<MsgAlarm>> pListeners, double tDelta, bool pIsReviving = false)
+        {
+            foreach (MsgAlarm tMsg in pListeners[tDelta < 0 ? "weatherSequel" : "weather"])     // pick channel "weather" if we're in threshold of pTriggerTime
+            {                                                                                   // pick channel "weatherSequel" if we're in offset of pTriggerTime
+                MsgAlarmWeather tReceiverMsg = new MsgAlarmWeather(this.mTriggerString ?? "", this.mTriggerInt!.Value);
+                if (tMsg.CompareMsg(tReceiverMsg))
+                {
+                    if (!pIsReviving && this.mMsgCheckCounter < 3)
+                    {
+                        PluginLog.LogDebug(String.Format("CHECK VERIFYING: ({6}) Alarm's msgAlarm check is true, but needs verifying! (del={3} ch={0} lstMsg={1} almMsg={2}) (w={4}) (wSq={5})",
+                                                                            tDelta < 0 ? "weatherSequel" : "weather",
+                                                                            tMsg._msg,
+                                                                            tReceiverMsg._msg,
+                                                                            tDelta,
+                                                                            String.Join(", ", pListeners["weather"].Select(o => o._msg)),
+                                                                            String.Join(", ", pListeners["weatherSequel"].Select(o => o._msg)),
+                                                                            this.mMsgCheckCounter
+                                                                            ));
+                        this.mMsgCheckCounter++;
+                        return false;
+                    }
+                    PluginLog.LogDebug(String.Format("CHECK SUCCEEDED: Alarm's msgAlarm check is true! (del={3} ch={0} lstMsg={1} almMsg={2}) (w={4}) (wSq={5})",
+                                                    tDelta < 0 ? "weatherSequel" : "weather",
+                                                    tMsg._msg,
+                                                    tReceiverMsg._msg,
+                                                    tDelta,
+                                                    String.Join(", ", pListeners["weather"].Select(o => o._msg)),
+                                                    String.Join(", ", pListeners["weatherSequel"].Select(o => o._msg))
+                                                    ));
+                    this.mMsgCheckCounter = 0;
+                    return true;
+                }
+            }
+            PluginLog.LogDebug(String.Format("CHECK FAILED: No msg is true. (del={1} ch={0} (w={2}) (wSq={3})",
+                                            tDelta < 0 ? "weatherSequel" : "weather",
+                                            tDelta,
+                                            String.Join(", ", pListeners["weather"].Select(o => o._msg)),
+                                            String.Join(", ", pListeners["weatherSequel"].Select(o => o._msg))
+                                            ));
+            this.mMsgCheckCounter = 0;
+            return false;
         }
 
         public override string Serialize()

--- a/BozjaBuddy/Data/Alarm/MsgAlarm.cs
+++ b/BozjaBuddy/Data/Alarm/MsgAlarm.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection.Metadata.Ecma335;
+
+namespace BozjaBuddy.Data.Alarm
+{
+    public class MsgAlarm
+    {
+        public string _msg = "";
+
+        protected MsgAlarm()
+        { 
+        }
+        public MsgAlarm(string pContent)
+        {
+            this._msg = pContent;
+        }
+        public virtual bool CompareMsg(MsgAlarm pMsgIn)
+        {
+            if (pMsgIn._msg == this._msg) return true;
+            return false;
+        }
+    }
+}

--- a/BozjaBuddy/Data/Alarm/MsgAlarmWeather.cs
+++ b/BozjaBuddy/Data/Alarm/MsgAlarmWeather.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BozjaBuddy.Data.Alarm
+{
+    public class MsgAlarmWeather : MsgAlarm
+    {
+        public MsgAlarmWeather(string pTerritoryId, int pWeatherId)
+        {
+            this._msg = $"{pTerritoryId}{pWeatherId}";
+        }
+    }
+}

--- a/BozjaBuddy/Data/BBDataManager.cs
+++ b/BozjaBuddy/Data/BBDataManager.cs
@@ -315,8 +315,11 @@ namespace BozjaBuddy.Data
             pPlugin.mBBDataManager.mGeneralObjects[pGenObj.GetGenId()] = pGenObj;
             AuxiliaryViewerSection.BindToGenObj(pPlugin, pGenObj.GetGenId());
             // Write to disc
-            pPlugin.mBBDataManager.SaveLoadouts();
-            AuxiliaryViewerSection.mTenpLoadout = null;
+            if (typeof(T) == typeof(Loadout))
+            {
+                pPlugin.mBBDataManager.SaveLoadouts();
+                AuxiliaryViewerSection.mTenpLoadout = null;
+            }
             AuxiliaryViewerSection.mIsRefreshRequired = true;
         }
         /// <summary>
@@ -332,8 +335,11 @@ namespace BozjaBuddy.Data
             AuxiliaryViewerSection.mTabGenIdsToDraw.Remove(pGenObj.GetGenId());
             AuxiliaryViewerSection.mIsRefreshRequired = true;
             // Write to disc
-            pPlugin.mBBDataManager.SaveLoadouts();
-            AuxiliaryViewerSection.mTenpLoadout = null;
+            if (typeof(T) == typeof(Loadout))
+            {
+                pPlugin.mBBDataManager.SaveLoadouts();
+                AuxiliaryViewerSection.mTenpLoadout = null;
+            }
         }
     }
 

--- a/BozjaBuddy/Filter/FilterNone.cs
+++ b/BozjaBuddy/Filter/FilterNone.cs
@@ -1,0 +1,26 @@
+﻿using BozjaBuddy.Data;
+using ImGuiNET;
+
+namespace BozjaBuddy.Filter
+{
+    internal class FilterNone : Filter
+    {
+        public override string mFilterName { get; set; } = "none";
+
+        protected FilterNone() { }
+
+        public FilterNone(bool pIsFilteringActive, string pFilterName)
+        {
+            this.mFilterName = pFilterName;
+            Init();
+            EnableFiltering(pIsFilteringActive);
+        }
+
+        public override void DrawFilterGUI()
+        {
+            ImGui.Text(this.mFilterName);
+        }
+
+        public override string GetCurrValue() => mCurrValue;
+    }
+}

--- a/BozjaBuddy/GUI/GUIAlarm.cs
+++ b/BozjaBuddy/GUI/GUIAlarm.cs
@@ -1,0 +1,129 @@
+﻿using BozjaBuddy.Data.Alarm;
+using BozjaBuddy.Utils;
+using Dalamud.Interface.Colors;
+using Dalamud.Interface.Components;
+using Dalamud.Logging;
+using ImGuiNET;
+using System;
+using System.Collections.Generic;
+
+namespace BozjaBuddy.GUI
+{
+    internal class GUIAlarm
+    {
+        public static string GUI_ID = "puCreateAlarm";
+        private static bool _kIsResetting = false;
+        private static Dictionary<int, string> _kErrors = new Dictionary<int, string>();
+        private static string kFieldName = "Alarm Name";
+        private static DateTime kDateTime = new DateTime();
+        private static string kFieldDateDD = "31";
+        private static string kFieldDateMM = "12";
+        private static string kFieldDateYYYY = "1999";
+        private static string kFieldDateHh = "24";
+        private static string kFieldDateMm = "59";
+        private static string kFieldDateSs = "59";
+        private static int kFieldDuration = 0;
+        private static bool kFieldIsRevivable = false;
+
+        public static void CreatePopupCreateAlarm(string pGUI_Key)
+        {
+            ImGui.OpenPopup($"{GUIAlarm.GUI_ID}##{pGUI_Key}");
+        }
+        public static void DrawPopupCreateAlarm<T>(Plugin pPlugin, string pGUI_Key, int pTriggerInt, string? pNameSuggestion = null) where T : Alarm, new()
+        {
+            if (!GUIAlarm._kIsResetting)
+            {
+                GUIAlarm.ResetFields();
+            }
+            if (ImGui.BeginPopup($"{GUIAlarm.GUI_ID}##{pGUI_Key}"))
+            {
+                // Text inputs
+                GUIAlarm._kIsResetting = true;
+                GUIAlarm.kFieldName = pNameSuggestion ?? GUIAlarm.kFieldName;
+                ImGui.BeginGroup();
+                ImGui.PushItemWidth(ImGui.GetFontSize() * 30);
+                ImGui.InputText("##name", ref GUIAlarm.kFieldName, 120);
+                ImGui.PopItemWidth();
+                if (typeof(T) == typeof(AlarmTime))
+                {
+                    ImGui.Text("at ");
+                    ImGui.PushItemWidth(ImGui.GetFontSize() * 2);
+                    ImGui.PushItemWidth(ImGui.GetFontSize() * 4);
+                    ImGui.SameLine(); ImGui.InputTextWithHint("##yyyy", "YYYY", ref GUIAlarm.kFieldDateYYYY, 4, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
+                    ImGui.PopItemWidth();
+                    ImGui.SameLine(); ImGui.InputTextWithHint("##mm", "MM", ref GUIAlarm.kFieldDateMM, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
+                    ImGui.SameLine(); ImGui.InputTextWithHint("##dd", "DD", ref GUIAlarm.kFieldDateDD, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
+                    ImGui.SameLine(); ImGui.InputTextWithHint("##Hh", "hh", ref GUIAlarm.kFieldDateHh, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
+                    ImGui.SameLine(); ImGui.InputTextWithHint("##Mm", "mm", ref GUIAlarm.kFieldDateMm, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
+                    ImGui.SameLine(); ImGui.InputTextWithHint("##Ss", "ss", ref GUIAlarm.kFieldDateSs, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
+                    ImGui.Text("for ");
+                    ImGui.PushItemWidth(ImGui.GetFontSize() * 4);
+                    ImGui.InputInt("##duration", ref GUIAlarm.kFieldDuration, 1, 1, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
+                    ImGui.PopItemWidth();
+                    ImGui.Text("s");
+                    ImGui.PopItemWidth();
+                }
+                ImGui.EndGroup();
+
+                ImGui.SameLine();
+
+                // Buttons
+                ImGui.BeginGroup();
+                if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.ArrowsSpin))
+                {
+                    GUIAlarm.kFieldIsRevivable = !GUIAlarm.kFieldIsRevivable;
+                }
+                ImGui.SameLine(); ImGui.Text(GUIAlarm.kFieldIsRevivable ? "Repeat" : "Once");
+                if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Save))
+                {
+                    if (DateTime.TryParse($"{GUIAlarm.kFieldDateYYYY}-{GUIAlarm.kFieldDateMM}-{GUIAlarm.kFieldDateDD} {GUIAlarm.kFieldDateHh}:{GUIAlarm.kFieldDateMm}:{GUIAlarm.kFieldDateSs}", out GUIAlarm.kDateTime))
+                    {
+                        T tTempAlarm = new T();
+                        tTempAlarm.Init(typeof(T) == typeof(AlarmTime) ? GUIAlarm.kDateTime : null,
+                                        pTriggerInt,
+                                        GUIAlarm.kFieldName,
+                                        GUIAlarm.kFieldDuration,
+                                        true,
+                                        GUIAlarm.kFieldIsRevivable);
+                        pPlugin.AlarmManager.AddAlarm(tTempAlarm);
+
+                        ImGui.CloseCurrentPopup();
+                    }
+                    else if (!GUIAlarm._kErrors.ContainsKey(0))
+                    {
+                        GUIAlarm._kErrors.Add(0, "Incorrect date value.");
+                    }
+                }
+                UtilsGUI.ShowHelpMarker(AlarmWeather.kToolTip);
+                ImGui.EndGroup();
+
+                // Error
+                foreach (string iErrString in GUIAlarm._kErrors.Values)
+                {
+                    ImGui.TextColored(ImGuiColors.DPSRed, iErrString);
+                }
+
+                ImGui.EndPopup();
+            }
+        }
+        public static void ResetPopup()
+        {
+            GUIAlarm._kIsResetting = true;
+        }
+        private static void ResetFields()
+        {
+            GUIAlarm._kIsResetting = false;
+            GUIAlarm._kErrors.Clear();
+            GUIAlarm.kFieldName = "Alarm Name";
+            GUIAlarm.kDateTime = new DateTime();
+            GUIAlarm.kFieldDateDD = "31";
+            GUIAlarm.kFieldDateMM = "12";
+            GUIAlarm.kFieldDateYYYY = "1999";
+            GUIAlarm.kFieldDateHh = "24";
+            GUIAlarm.kFieldDateMm = "59";
+            GUIAlarm.kFieldDateSs = "59";
+            GUIAlarm.kFieldDuration = 0;
+            GUIAlarm.kFieldIsRevivable = false;
+        }
+    }
+}

--- a/BozjaBuddy/GUI/GUIAlarm.cs
+++ b/BozjaBuddy/GUI/GUIAlarm.cs
@@ -1,129 +1,499 @@
 ﻿using BozjaBuddy.Data.Alarm;
+using BozjaBuddy.GUI.Sections;
 using BozjaBuddy.Utils;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Components;
 using Dalamud.Logging;
+using FFXIVClientStructs.Interop.Attributes;
 using ImGuiNET;
 using System;
+using System.CodeDom;
 using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms.VisualStyles;
 
 namespace BozjaBuddy.GUI
 {
     internal class GUIAlarm
     {
         public static string GUI_ID = "puCreateAlarm";
-        private static bool _kIsResetting = false;
         private static Dictionary<int, string> _kErrors = new Dictionary<int, string>();
         private static string kFieldName = "Alarm Name";
-        private static DateTime kDateTime = new DateTime();
+        private static DateTime? kDateTime = null;
         private static string kFieldDateDD = "31";
         private static string kFieldDateMM = "12";
         private static string kFieldDateYYYY = "1999";
-        private static string kFieldDateHh = "24";
+        private static string kFieldDateHh = "23";
         private static string kFieldDateMm = "59";
         private static string kFieldDateSs = "59";
         private static int kFieldDuration = 0;
+        private static int kFieldOffset = 0;
         private static bool kFieldIsRevivable = false;
+        private static string? kFieldTriggerString = "";
+        private static int? kFieldTriggerInt = 0;
 
-        public static void CreatePopupCreateAlarm(string pGUI_Key)
+        private static string[] kAlarmLabels = { "Time", "Weather", "FateCE" };
+        private static List<string> kAlarmTerritories = WeatherBarSection._mTerritories.Keys.ToList();
+        private static List<int> kAlarmWeathers = WeatherBarSection._mWeatherNames.Keys.ToList();
+        private static int kComboCurrLabel = 0;
+        private static string kComboCurrTerritoryId = "";
+        private static int kComboCurrWeatherId = 0;
+        unsafe private static ImGuiTextFilterPtr kFilter = new ImGuiTextFilterPtr(ImGuiNative.ImGuiTextFilter_ImGuiTextFilter(null));
+        private static int kComboCurrFateId = 0;
+        
+        /// <summary>Do nothing if pop-up has already been opened.</summary>
+        public static void CreateACPU(string pGUI_Key, bool pUseDateTimeNow = true, string? pNameSuggestion = null)
         {
+            if (ImGui.IsPopupOpen($"{GUIAlarm.GUI_ID}##{pGUI_Key}")) return;
+            GUIAlarm.ResetFields(pUseDateTimeNow: pUseDateTimeNow, pNameSuggestion:pNameSuggestion);
             ImGui.OpenPopup($"{GUIAlarm.GUI_ID}##{pGUI_Key}");
         }
-        public static void DrawPopupCreateAlarm<T>(Plugin pPlugin, string pGUI_Key, int pTriggerInt, string? pNameSuggestion = null) where T : Alarm, new()
+        public static void CreateACPU(string pGUI_Key, Alarm pAlarm)
         {
-            if (!GUIAlarm._kIsResetting)
+            if (ImGui.IsPopupOpen($"{GUIAlarm.GUI_ID}##{pGUI_Key}")) return;
+            GUIAlarm.ResetFields(pAlarm);
+            ImGui.OpenPopup($"{GUIAlarm.GUI_ID}##{pGUI_Key}");
+        }
+        private static void DrawComboTerritory(float tWidth = 200, Alarm? pAlarmToEdit = null)
+        {
+            if (GUIAlarm.kComboCurrTerritoryId == "")
+                GUIAlarm.kComboCurrTerritoryId = pAlarmToEdit == null 
+                                                 ? WeatherBarSection._mTerritories.Keys.ToList()[0]
+                                                 : (pAlarmToEdit.mTriggerString ?? WeatherBarSection._mTerritories.Keys.ToList()[0]);
+            ImGui.PushItemWidth(tWidth);
+            if (ImGui.BeginCombo(
+                "##aTerritory", 
+                WeatherBarSection._mTerritories[GUIAlarm.kComboCurrTerritoryId]))
             {
-                GUIAlarm.ResetFields();
+                foreach (string iTerritoryId in WeatherBarSection._mTerritories.Keys)
+                {
+                    if (ImGui.Selectable(WeatherBarSection._mTerritories[iTerritoryId]))
+                    {
+                        GUIAlarm.kComboCurrTerritoryId = iTerritoryId;
+                        GUIAlarm.kFieldTriggerString = GUIAlarm.kComboCurrTerritoryId;
+                    }
+                }
+                ImGui.EndCombo();
             }
+            ImGui.PopItemWidth();
+        }
+        private static void DrawComboWeather(float tWidth = 200, Alarm? pAlarmToEdit = null)
+        {
+            if (GUIAlarm.kComboCurrWeatherId == 0)
+                GUIAlarm.kComboCurrWeatherId = pAlarmToEdit == null
+                                               ? WeatherBarSection._mWeatherNames.Keys.ToList()[0]
+                                               : (pAlarmToEdit.mTriggerInt ?? WeatherBarSection._mWeatherNames.Keys.ToList()[0]);
+            ImGui.PushItemWidth(tWidth);
+            if (ImGui.BeginCombo("##aWeather", WeatherBarSection._mWeatherNames[GUIAlarm.kComboCurrWeatherId]))
+            {
+                foreach (int iWeatherId in WeatherBarSection._mWeatherNames.Keys)
+                {
+                    if (ImGui.Selectable(WeatherBarSection._mWeatherNames[iWeatherId]))
+                    {
+                        GUIAlarm.kComboCurrWeatherId = iWeatherId;
+                        GUIAlarm.kFieldTriggerInt = GUIAlarm.kComboCurrWeatherId;
+                    }
+                }
+                ImGui.EndCombo();
+            }            
+            ImGui.PopItemWidth();
+        }
+        private static void DrawComboFateCe(Plugin pPlugin, float tWidth = 200, Alarm? pAlarmToEdit = null)
+        {
+            Dictionary<int, Data.Fate> tFates = pPlugin.mBBDataManager.mFates;
+            if (GUIAlarm.kComboCurrFateId == 0)
+                GUIAlarm.kComboCurrFateId = pAlarmToEdit == null
+                                            ? tFates.Values.ToList()[0].mId
+                                            : (pAlarmToEdit.mTriggerInt ?? tFates.Values.ToList()[0].mId);
+            ImGui.PushItemWidth(tWidth);
+            if (ImGui.BeginCombo("##aFce", tFates[GUIAlarm.kComboCurrFateId].mName))
+            {
+                unsafe
+                {
+                    GUIAlarm.kFilter.Draw("");
+                    foreach (Data.Fate iFate in tFates.Values)
+                    {
+                        if (GUIAlarm.kFilter.PassFilter(iFate.mName) 
+                            && ImGui.Selectable($"{iFate.mId} {iFate.mName}"))
+                        {
+                            GUIAlarm.kComboCurrFateId = iFate.mId;
+                            GUIAlarm.kFieldTriggerInt = GUIAlarm.kComboCurrFateId;
+                        }
+                    }
+                }
+                ImGui.EndCombo();
+            }
+            ImGui.PopItemWidth();
+        }
+        private static void DrawACPULabel(string? pReprString, string? pTooltip, bool pIsEditable = false)
+        {
+            if (pIsEditable)
+            {
+                GUIAlarm.DrawACPULabel_Editable();
+            }
+            else
+            {
+                GUIAlarm.DrawACPULabel_Default(pReprString, pTooltip);
+            }
+        }
+        private static void DrawACPULabel_Default(string? pReprString, string? pTooltip)
+        {
+            ImGui.Text(pReprString ?? Alarm.kReprString);
+            ImGui.SameLine(); UtilsGUI.ShowHelpMarker(pTooltip ?? Alarm.kToolTip);
+        }
+        private static void DrawACPULabel_Editable()
+        {
+            ImGui.PushItemWidth(80);
+            if (ImGui.BeginCombo("##aType", GUIAlarm.kAlarmLabels[GUIAlarm.kComboCurrLabel]))
+            {
+                for (int i = 0; i < kAlarmLabels.Length; i++)
+                {
+                    if (ImGui.Selectable(GUIAlarm.kAlarmLabels[i]))
+                    {
+                        GUIAlarm.kComboCurrLabel = i;
+                    }
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.BeginTooltip();
+                        ImGui.PushTextWrapPos(450.0f);
+                        switch (i)
+                        {
+                            case 0:
+                                ImGui.TextUnformatted(AlarmTime.kToolTip);
+                                break;
+                            case 1:
+                                ImGui.TextUnformatted(AlarmWeather.kToolTip);
+                                break;
+                            case 2:
+                                ImGui.TextUnformatted(AlarmFateCe.kToolTip);
+                                break;
+                            default:
+                                ImGui.TextUnformatted(Alarm.kToolTip);
+                                break;
+                        }
+                        ImGui.PopTextWrapPos();
+                        ImGui.EndTooltip();
+                    }
+                }
+                ImGui.EndCombo();
+            }
+            ImGui.PopItemWidth();
+        }
+        private static void DrawACPUTextInput_Default()
+        {
+            // Text inputs
+            ImGui.PushItemWidth(ImGui.GetFontSize() * 30);
+            ImGui.InputText("##name", ref GUIAlarm.kFieldName, 120);
+            ImGui.PopItemWidth();
+            ImGui.PushItemWidth(ImGui.GetFontSize() * 6);
+            ImGui.InputInt("##duration", ref GUIAlarm.kFieldDuration, 10, 10, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll);
+            ImGui.SameLine(); UtilsGUI.TextWithHelpMarker(
+                                                "Audio duration [s]",
+                                                $"The duration that the alarm's audio will play.\nRange from {Alarm.kDurationMin} to {Alarm.kDurationMax}",
+                                                UtilsGUI.Colors.BackgroundText_Grey);
+            ImGui.InputInt("##offset", ref GUIAlarm.kFieldOffset, 10, 10, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll);
+            ImGui.SameLine(); UtilsGUI.TextWithHelpMarker(
+                                                "Offset [s]",
+                                                $"Offset to alarm.\ne.g. An alarm for Raining will trigger X seconds before it actually rain. X is its offset.\nRange from {Alarm.kOffsetMin} to {Alarm.kOffsetMax}.",
+                                                UtilsGUI.Colors.BackgroundText_Grey);
+            ImGui.PopItemWidth();
+        }
+        private static void DrawACPUButton_Default<T>(Plugin pPlugin, DateTime? pTriggerTime = null) where T : Alarm, new()
+        {
+            if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Save))
+            {
+                DateTime tTempDateTime = DateTime.Now;
+                if (DateTime.TryParse(
+                        $"{GUIAlarm.kFieldDateYYYY}-{GUIAlarm.kFieldDateMM}-{GUIAlarm.kFieldDateDD} {GUIAlarm.kFieldDateHh}:{GUIAlarm.kFieldDateMm}:{GUIAlarm.kFieldDateSs}",
+                        out tTempDateTime))
+                {
+                    GUIAlarm.kDateTime = tTempDateTime;
+                }
+                else if (!GUIAlarm._kErrors.ContainsKey(0))
+                {
+                    GUIAlarm._kErrors.Add(0, "Incorrect date value.");
+                }
+                T tTempAlarm = new T();
+                tTempAlarm.Init(pTriggerTime ?? GUIAlarm.kDateTime,
+                                GUIAlarm.kFieldTriggerInt,
+                                GUIAlarm.kFieldName,
+                                GUIAlarm.kFieldDuration,
+                                true,
+                                GUIAlarm.kFieldIsRevivable,
+                                GUIAlarm.kFieldTriggerString,
+                                GUIAlarm.kFieldOffset);
+                pPlugin.AlarmManager.AddAlarm(tTempAlarm);
+
+                ImGui.CloseCurrentPopup();
+                pPlugin.WindowSystem.GetWindow("Alarm - BozjaBuddy")!.IsOpen = true;
+            }
+        }
+        private static void DrawACPUButton_Edit<T>(Plugin pPlugin, Alarm pAlarm) where T : Alarm
+        {
+            if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Save))
+            {
+                DateTime tTempDateTime = DateTime.Now;
+                if (DateTime.TryParse(
+                        $"{GUIAlarm.kFieldDateYYYY}-{GUIAlarm.kFieldDateMM}-{GUIAlarm.kFieldDateDD} {GUIAlarm.kFieldDateHh}:{GUIAlarm.kFieldDateMm}:{GUIAlarm.kFieldDateSs}",
+                        out tTempDateTime))
+                {
+                    GUIAlarm.kDateTime = tTempDateTime;
+                }
+                else if (!GUIAlarm._kErrors.ContainsKey(0))
+                {
+                    GUIAlarm._kErrors.Add(0, "Incorrect date value.");
+                }
+
+                pAlarm.mTriggerTime = GUIAlarm.kDateTime;
+                pAlarm.mTriggerInt = GUIAlarm.kFieldTriggerInt;
+                pAlarm.mTriggerString = GUIAlarm.kFieldTriggerString;
+                pAlarm.mName = GUIAlarm.kFieldName;
+                pAlarm.mDuration = GUIAlarm.kFieldDuration;
+                pAlarm.mIsRevivable = GUIAlarm.kFieldIsRevivable;
+                pAlarm.mOffset = GUIAlarm.kFieldOffset;
+
+                ImGui.CloseCurrentPopup();
+                pPlugin.WindowSystem.GetWindow("Alarm - BozjaBuddy")!.IsOpen = true;
+            }            
+        }
+        public static void DrawACPU_Weather(Plugin pPlugin,
+                                    string pGUI_Key,
+                                    int? pTriggerInt = null,
+                                    string? pTriggerString = null,
+                                    DateTime? pTriggerTime = null,
+                                    bool pIsLabelEditable = false,
+                                    Alarm? pAlarmToEdit = null)
+        {
             if (ImGui.BeginPopup($"{GUIAlarm.GUI_ID}##{pGUI_Key}"))
             {
-                // Text inputs
-                GUIAlarm._kIsResetting = true;
-                GUIAlarm.kFieldName = pNameSuggestion ?? GUIAlarm.kFieldName;
-                ImGui.BeginGroup();
-                ImGui.PushItemWidth(ImGui.GetFontSize() * 30);
-                ImGui.InputText("##name", ref GUIAlarm.kFieldName, 120);
-                ImGui.PopItemWidth();
-                if (typeof(T) == typeof(AlarmTime))
+                if (pAlarmToEdit == null)
                 {
-                    ImGui.Text("at ");
-                    ImGui.PushItemWidth(ImGui.GetFontSize() * 2);
-                    ImGui.PushItemWidth(ImGui.GetFontSize() * 4);
-                    ImGui.SameLine(); ImGui.InputTextWithHint("##yyyy", "YYYY", ref GUIAlarm.kFieldDateYYYY, 4, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
-                    ImGui.PopItemWidth();
-                    ImGui.SameLine(); ImGui.InputTextWithHint("##mm", "MM", ref GUIAlarm.kFieldDateMM, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
-                    ImGui.SameLine(); ImGui.InputTextWithHint("##dd", "DD", ref GUIAlarm.kFieldDateDD, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
-                    ImGui.SameLine(); ImGui.InputTextWithHint("##Hh", "hh", ref GUIAlarm.kFieldDateHh, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
-                    ImGui.SameLine(); ImGui.InputTextWithHint("##Mm", "mm", ref GUIAlarm.kFieldDateMm, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
-                    ImGui.SameLine(); ImGui.InputTextWithHint("##Ss", "ss", ref GUIAlarm.kFieldDateSs, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
-                    ImGui.Text("for ");
-                    ImGui.PushItemWidth(ImGui.GetFontSize() * 4);
-                    ImGui.InputInt("##duration", ref GUIAlarm.kFieldDuration, 1, 1, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AllowTabInput);
-                    ImGui.PopItemWidth();
-                    ImGui.Text("s");
-                    ImGui.PopItemWidth();
+                    GUIAlarm.kFieldTriggerString = pTriggerString ?? GUIAlarm.kFieldTriggerString ?? WeatherBarSection._mTerritories.Keys.ToList()[0];
+                    GUIAlarm.kFieldTriggerInt = pTriggerInt ?? GUIAlarm.kFieldTriggerInt ?? WeatherBarSection._mWeatherNames.Keys.ToList()[0];
+                }
+                else
+                {
+                    GUIAlarm.kFieldTriggerString = GUIAlarm.kComboCurrTerritoryId;
+                    GUIAlarm.kFieldTriggerInt = GUIAlarm.kComboCurrWeatherId;
+                }
+
+                // Text input
+                ImGui.BeginGroup();
+                GUIAlarm.DrawACPUTextInput_Default();
+                if (pIsLabelEditable || pAlarmToEdit != null)
+                {
+                    GUIAlarm.DrawComboTerritory();
+                    ImGui.SameLine(); GUIAlarm.DrawComboWeather(pAlarmToEdit: pAlarmToEdit);
                 }
                 ImGui.EndGroup();
 
                 ImGui.SameLine();
 
-                // Buttons
+                // Labels and button
                 ImGui.BeginGroup();
+                GUIAlarm.DrawACPULabel(AlarmWeather.kReprString, AlarmWeather.kToolTip, pIsLabelEditable);
+                if (pAlarmToEdit == null)
+                    GUIAlarm.DrawACPUButton_Default<AlarmWeather>(pPlugin, pTriggerTime);
+                else
+                    GUIAlarm.DrawACPUButton_Edit<AlarmWeather>(pPlugin, pAlarmToEdit);
                 if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.ArrowsSpin))
                 {
                     GUIAlarm.kFieldIsRevivable = !GUIAlarm.kFieldIsRevivable;
                 }
                 ImGui.SameLine(); ImGui.Text(GUIAlarm.kFieldIsRevivable ? "Repeat" : "Once");
-                if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Save))
-                {
-                    if (DateTime.TryParse($"{GUIAlarm.kFieldDateYYYY}-{GUIAlarm.kFieldDateMM}-{GUIAlarm.kFieldDateDD} {GUIAlarm.kFieldDateHh}:{GUIAlarm.kFieldDateMm}:{GUIAlarm.kFieldDateSs}", out GUIAlarm.kDateTime))
-                    {
-                        T tTempAlarm = new T();
-                        tTempAlarm.Init(typeof(T) == typeof(AlarmTime) ? GUIAlarm.kDateTime : null,
-                                        pTriggerInt,
-                                        GUIAlarm.kFieldName,
-                                        GUIAlarm.kFieldDuration,
-                                        true,
-                                        GUIAlarm.kFieldIsRevivable);
-                        pPlugin.AlarmManager.AddAlarm(tTempAlarm);
-
-                        ImGui.CloseCurrentPopup();
-                    }
-                    else if (!GUIAlarm._kErrors.ContainsKey(0))
-                    {
-                        GUIAlarm._kErrors.Add(0, "Incorrect date value.");
-                    }
-                }
-                UtilsGUI.ShowHelpMarker(AlarmWeather.kToolTip);
                 ImGui.EndGroup();
-
-                // Error
-                foreach (string iErrString in GUIAlarm._kErrors.Values)
-                {
-                    ImGui.TextColored(ImGuiColors.DPSRed, iErrString);
-                }
 
                 ImGui.EndPopup();
             }
         }
-        public static void ResetPopup()
+        public static void DrawACPU_Time(Plugin pPlugin,
+                                    string pGUI_Key,
+                                    DateTime? pTriggerTime = null,
+                                    bool pIsLabelEditable = false,
+                                    bool pIsInEditMode = false,
+                                    Alarm? pAlarmToEdit = null)
         {
-            GUIAlarm._kIsResetting = true;
+            if (ImGui.BeginPopup($"{GUIAlarm.GUI_ID}##{pGUI_Key}"))
+            {
+                // Text input
+                ImGui.BeginGroup();
+                GUIAlarm.DrawACPUTextInput_Default();
+                ImGui.Text("Time [YYYY/MM/DD hh/mm/ss]");
+                ImGui.PushItemWidth(ImGui.GetFontSize() * 2);
+                ImGui.PushItemWidth(ImGui.GetFontSize() * 4);
+                ImGui.SameLine(); ImGui.InputTextWithHint("##yyyy", "YYYY", ref GUIAlarm.kFieldDateYYYY, 4, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll);
+                ImGui.PopItemWidth();
+                ImGui.SameLine(); ImGui.Text("/");
+                ImGui.SameLine(); ImGui.InputTextWithHint("##mm", "MM", ref GUIAlarm.kFieldDateMM, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll);
+                ImGui.SameLine(); ImGui.Text("/");
+                ImGui.SameLine(); ImGui.InputTextWithHint("##dd", "DD", ref GUIAlarm.kFieldDateDD, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll);
+                ImGui.SameLine(); ImGui.Spacing();
+                ImGui.SameLine(); ImGui.InputTextWithHint("##Hh", "hh", ref GUIAlarm.kFieldDateHh, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll);
+                ImGui.SameLine(); ImGui.Text(":");
+                ImGui.SameLine(); ImGui.InputTextWithHint("##Mm", "mm", ref GUIAlarm.kFieldDateMm, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll);
+                ImGui.SameLine(); ImGui.Text(":");
+                ImGui.SameLine(); ImGui.InputTextWithHint("##Ss", "ss", ref GUIAlarm.kFieldDateSs, 2, ImGuiInputTextFlags.CharsDecimal | ImGuiInputTextFlags.AutoSelectAll);
+                ImGui.PopItemWidth();
+                ImGui.EndGroup();
+
+                ImGui.SameLine();
+
+                // Labels and button
+                ImGui.BeginGroup();
+                GUIAlarm.DrawACPULabel(AlarmTime.kReprString, AlarmTime.kToolTip, pIsLabelEditable);
+                if (pAlarmToEdit == null)
+                    GUIAlarm.DrawACPUButton_Default<AlarmTime>(pPlugin, pTriggerTime);
+                else
+                    GUIAlarm.DrawACPUButton_Edit<AlarmTime>(pPlugin, pAlarmToEdit);
+                ImGui.EndGroup();
+
+                ImGui.EndPopup();
+            }
         }
-        private static void ResetFields()
+        public static void DrawACPU_FateCe(Plugin pPlugin,
+                                    string pGUI_Key,
+                                    int? pTriggerInt = null,
+                                    DateTime? pTriggerTime = null,
+                                    bool pIsLabelEditable = false,
+                                    bool pIsInEditMode = false,
+                                    Alarm? pAlarmToEdit = null)
         {
-            GUIAlarm._kIsResetting = false;
+            if (ImGui.BeginPopup($"{GUIAlarm.GUI_ID}##{pGUI_Key}"))
+            {
+                if (pAlarmToEdit == null)
+                {
+                    GUIAlarm.kFieldTriggerInt = pTriggerInt ?? GUIAlarm.kFieldTriggerInt ?? pPlugin.mBBDataManager.mFates.Keys.ToList()[0];
+                }
+                else
+                {
+                    GUIAlarm.kFieldTriggerString = GUIAlarm.kComboCurrTerritoryId;
+                    GUIAlarm.kFieldTriggerInt = GUIAlarm.kComboCurrWeatherId;
+                }
+
+                // Text input
+                ImGui.BeginGroup();
+                GUIAlarm.DrawACPUTextInput_Default();
+                if (pIsLabelEditable || pAlarmToEdit != null)
+                {
+                    GUIAlarm.DrawComboFateCe(pPlugin, pAlarmToEdit: pAlarmToEdit);
+                    GUIAlarm.kFieldTriggerInt = pPlugin.mBBDataManager.mFates[GUIAlarm.kComboCurrFateId].mId;
+                }
+                ImGui.EndGroup();
+
+                ImGui.SameLine();
+
+                // Labels and button
+                ImGui.BeginGroup();
+                GUIAlarm.DrawACPULabel(AlarmFateCe.kReprString, AlarmFateCe.kToolTip, pIsLabelEditable);
+                if (pAlarmToEdit == null)
+                    GUIAlarm.DrawACPUButton_Default<AlarmFateCe>(pPlugin, pTriggerTime);
+                else
+                    GUIAlarm.DrawACPUButton_Edit<AlarmFateCe>(pPlugin, pAlarmToEdit);
+                if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.ArrowsSpin))
+                {
+                    GUIAlarm.kFieldIsRevivable = !GUIAlarm.kFieldIsRevivable;
+                }
+                ImGui.SameLine(); ImGui.Text(GUIAlarm.kFieldIsRevivable ? "Repeat" : "Once");
+                ImGui.EndGroup();
+
+                ImGui.EndPopup();
+            }
+        }
+        public static void DrawACPU_All(Plugin pPlugin,
+                                    string pGUI_Key,
+                                    int? pTriggerInt = null,
+                                    string? pTriggerString = null,
+                                    DateTime? pTriggerTime = null)
+        {
+            switch (GUIAlarm.kComboCurrLabel)
+            {
+                case 0:
+                    GUIAlarm.DrawACPU_Time(
+                                        pPlugin,
+                                        pGUI_Key,
+                                        pTriggerTime,
+                                        true);
+                    break;
+                case 1:
+                    GUIAlarm.DrawACPU_Weather(
+                                        pPlugin,
+                                        pGUI_Key,
+                                        pTriggerInt,
+                                        pTriggerString,
+                                        pTriggerTime,
+                                        true);
+                    break;
+                case 2:
+                    GUIAlarm.DrawACPU_FateCe(
+                                        pPlugin,
+                                        pGUI_Key,
+                                        pTriggerInt,
+                                        pTriggerTime,
+                                        true);
+                    break;
+                default:
+                    GUIAlarm.DrawACPU_Time(
+                                        pPlugin,
+                                        pGUI_Key,
+                                        pTriggerTime,
+                                        true);
+                    break;
+            }
+        }
+
+        private static void ResetFields(bool pUseDateTimeNow = false, string? pNameSuggestion = null)
+        {
             GUIAlarm._kErrors.Clear();
-            GUIAlarm.kFieldName = "Alarm Name";
-            GUIAlarm.kDateTime = new DateTime();
-            GUIAlarm.kFieldDateDD = "31";
-            GUIAlarm.kFieldDateMM = "12";
-            GUIAlarm.kFieldDateYYYY = "1999";
-            GUIAlarm.kFieldDateHh = "24";
-            GUIAlarm.kFieldDateMm = "59";
-            GUIAlarm.kFieldDateSs = "59";
-            GUIAlarm.kFieldDuration = 0;
+
+            GUIAlarm.kFieldName = pNameSuggestion ?? "Alarm Name";
+            GUIAlarm.kDateTime = DateTime.Now;
+            if (pUseDateTimeNow)
+            {
+                GUIAlarm.kFieldDateDD = DateTime.Now.Day.ToString();
+                GUIAlarm.kFieldDateMM = DateTime.Now.Month.ToString();
+                GUIAlarm.kFieldDateYYYY = DateTime.Now.Year.ToString();
+                GUIAlarm.kFieldDateHh = DateTime.Now.Hour.ToString();
+                GUIAlarm.kFieldDateMm = DateTime.Now.Minute.ToString();
+                GUIAlarm.kFieldDateSs = DateTime.Now.Second.ToString();
+            }
+            else
+            {
+                GUIAlarm.kFieldDateDD = "31";
+                GUIAlarm.kFieldDateMM = "12";
+                GUIAlarm.kFieldDateYYYY = "1999";
+                GUIAlarm.kFieldDateHh = "24";
+                GUIAlarm.kFieldDateMm = "59";
+                GUIAlarm.kFieldDateSs = "59";
+            }
+            GUIAlarm.kFieldDuration = Alarm.kDurationMin;
+            GUIAlarm.kFieldOffset = Alarm.kOffsetMin;
             GUIAlarm.kFieldIsRevivable = false;
+            GUIAlarm.kFieldTriggerInt = null;
+            GUIAlarm.kFieldTriggerString = null;
+
+            GUIAlarm.kComboCurrTerritoryId = "";
+            GUIAlarm.kComboCurrWeatherId = 0;
+        }
+        private static void ResetFields(Alarm pAlarm)
+        {
+            GUIAlarm._kErrors.Clear();
+
+            GUIAlarm.kFieldName = pAlarm.mName;
+            GUIAlarm.kDateTime = pAlarm.mTriggerTime;
+            GUIAlarm.kFieldDuration = pAlarm.mDuration;
+            GUIAlarm.kFieldOffset = pAlarm.mOffset;
+            GUIAlarm.kFieldIsRevivable = pAlarm.mIsRevivable;
+            GUIAlarm.kFieldTriggerInt = pAlarm.mTriggerInt ?? null;
+            GUIAlarm.kFieldTriggerString = pAlarm.mTriggerString ?? null;
+
+            GUIAlarm.kFieldDateDD = pAlarm.mTriggerTime!.Value.Day.ToString();
+            GUIAlarm.kFieldDateMM = pAlarm.mTriggerTime!.Value.Month.ToString();
+            GUIAlarm.kFieldDateYYYY = pAlarm.mTriggerTime!.Value.Year.ToString();
+            GUIAlarm.kFieldDateHh = pAlarm.mTriggerTime!.Value.Hour.ToString();
+            GUIAlarm.kFieldDateMm = pAlarm.mTriggerTime!.Value.Minute.ToString();
+            GUIAlarm.kFieldDateSs = pAlarm.mTriggerTime!.Value.Second.ToString();
+
+            //foreach (WeatherBarSection._mTerritories[GUIAlarm.kAlarmTerritories[GUIAlarm.kComboCurrTerritory]])
         }
     }
 }

--- a/BozjaBuddy/GUI/Sections/AuxiliaryViewerSection.cs
+++ b/BozjaBuddy/GUI/Sections/AuxiliaryViewerSection.cs
@@ -322,6 +322,29 @@ namespace BozjaBuddy.GUI.Sections
         {
             ImGui.BeginChild("", new System.Numerics.Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y), false, ImGuiWindowFlags.None);
             ImGui.PushTextWrapPos(0);
+            // Fate chains
+            if (pObj.GetSalt() == GeneralObject.GeneralObjectSalt.Fate
+                && (this.mPlugin.mBBDataManager.mFates[pObj.mId].mChainFatePrev != -1
+                    || this.mPlugin.mBBDataManager.mFates[pObj.mId].mChainFateNext != -1))
+            {
+                int iCurrFateId = this.mPlugin.mBBDataManager.mFates[pObj.mId].mChainFatePrev != -1
+                    ? this.mPlugin.mBBDataManager.mFates[pObj.mId].mChainFatePrev
+                    : this.mPlugin.mBBDataManager.mFates[pObj.mId].mChainFateNext;
+                while (this.mPlugin.mBBDataManager.mFates[iCurrFateId].mChainFatePrev != -1)        // Find the starting point of FATE chain
+                    iCurrFateId = this.mPlugin.mBBDataManager.mFates[iCurrFateId].mChainFatePrev;
+                ImGui.Text("Chain: ");
+                do
+                {
+                    ImGui.SameLine();
+                    AuxiliaryViewerSection.GUISelectableLink(this.mPlugin,
+                        this.mPlugin.mBBDataManager.mFates[iCurrFateId].mName,
+                        this.mPlugin.mBBDataManager.mFates[iCurrFateId].GetGenId(),
+                        true);
+                    iCurrFateId = this.mPlugin.mBBDataManager.mFates[iCurrFateId].mChainFateNext;
+                }
+                while (iCurrFateId != -1);
+                ImGui.Separator();
+            }
             if (pObj.mIGMarkup == null) 
                 ImGui.TextUnformatted(pObj.mDescription);
             else
@@ -566,7 +589,6 @@ namespace BozjaBuddy.GUI.Sections
             unsafe
             {
                 AuxiliaryViewerSection.mFilter.Draw("");
-                int i = 0;
                 foreach (LostAction iAction in pPlugin.mBBDataManager.mLostActions.Values)
                 {
                     if (AuxiliaryViewerSection.mFilter.PassFilter(iAction.mName))

--- a/BozjaBuddy/GUI/Sections/GeneralSection.cs
+++ b/BozjaBuddy/GUI/Sections/GeneralSection.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using BozjaBuddy.Windows;
+using Dalamud.Interface.Components;
+using Dalamud.Interface.Windowing;
+using ImGuiNET;
+
+namespace BozjaBuddy.GUI.Sections
+{
+    internal class GeneralSection : Section, IDisposable
+    {
+        protected override Plugin mPlugin { get; set; }
+
+        public GeneralSection(Plugin pPlugin)
+        {
+            this.mPlugin = pPlugin;
+        }
+
+        public override bool DrawGUI()
+        {
+            // Button Config
+            if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Cog))
+            {
+                this.mPlugin.WindowSystem.GetWindow("Config - BozjaBuddy")!.IsOpen = true;
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text("Open config window.");
+                ImGui.EndTooltip();
+            }
+
+            ImGui.SameLine();
+            // Button Alarm
+            if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Bell))
+            {
+                this.mPlugin.WindowSystem.GetWindow("Alarm - BozjaBuddy")!.IsOpen = true;
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text("Open alarm window.");
+                ImGui.EndTooltip();
+            }
+            ImGui.SameLine();
+            // Alarm notification bar
+            AlarmWindow.DrawAlarmNotificationBar(this.mPlugin, "generalSection", pIsStretching: false, ImGui.GetContentRegionAvail().X / 4 + (float)2.5);
+            return true;
+        }
+        public override void DrawGUIDebug()
+        {
+
+        }
+
+        public override void Dispose() { }
+    }
+}

--- a/BozjaBuddy/GUI/Sections/WeatherBarSection.cs
+++ b/BozjaBuddy/GUI/Sections/WeatherBarSection.cs
@@ -8,6 +8,7 @@ using Lumina.Excel.GeneratedSheets;
 using System.Numerics;
 using BozjaBuddy.Data.Alarm;
 using Dalamud.Logging;
+using FFXIVWeather.Models;
 
 namespace BozjaBuddy.GUI.Sections
 {
@@ -17,7 +18,7 @@ namespace BozjaBuddy.GUI.Sections
 
         private TextureCollection mTextureCollection;
         public static Dictionary<string, string> _mTerritories = new Dictionary<string, string>() {
-                                                                                            { "n4b4", "Bozjan Southern Front" },
+                                                                                            { "n4b4", "Bozja" },
                                                                                             { "n4b6", "Zadnor" } 
                                                                                                     };
         public static string _mCurrTerritory = "n4b4";
@@ -29,6 +30,15 @@ namespace BozjaBuddy.GUI.Sections
             { 2, 0xAA4B4646 },  // Fair
             { 5, 0xAA4BEF23 },  // Wind
             { 15, 0xAAE3F2F3 }   // Snow
+        };
+        public static Dictionary<int, string> _mWeatherNames = new Dictionary<int, string>()
+        {
+            { 7, "Rain" },  // Rain
+            { 9, "Thunder" },   // Thunder
+            { 11, "Dust" },  // Dust
+            { 2, "Fair" },  // Fair
+            { 5, "Wind" },  // Wind
+            { 15, "Snow" }   // Snow
         };
 
         public static FFXIVWeatherService _mWeatherService = new FFXIVWeatherService();
@@ -73,18 +83,22 @@ namespace BozjaBuddy.GUI.Sections
             {
                 string tTempGUI_Key = $"weather{i}";
                 (FFXIVWeather.Models.Weather, DateTime) tWeather = WeatherBarSection._mForeCast[pTerritoryId][i];
+                DateTime tProcessedTime = Utils.Utils.ProcessToLocalTime(tWeather.Item2);
+
                 ImGui.SameLine();
                 ImGui.PushStyleColor(ImGuiCol.Button, WeatherBarSection._mWeatherColor[tWeather.Item1.Id]);
                 if (tWeather.Item2 != tWeatherCurr_bozja.Item2)
                 {
-                    if (ImGui.Button($"   ##{i}") && !ImGui.IsPopupOpen($"{GUIAlarm.GUI_ID}##{tTempGUI_Key}"))
+                    if (ImGui.Button($"   ##{i}"))
                     {
-                        GUIAlarm.CreatePopupCreateAlarm(tTempGUI_Key);
+                        GUIAlarm.CreateACPU(
+                            tTempGUI_Key,
+                            pNameSuggestion: $"{AlarmWeather.kReprString} {Alarm.GetIdCounter()} | {tWeather.Item1.GetName()} | {WeatherBarSection._mTerritories[pTerritoryId]}");
                     }
-                    else if (!ImGui.IsPopupOpen($"{GUIAlarm.GUI_ID}##{tTempGUI_Key}"))
-                    {
-                        GUIAlarm.ResetPopup();
-                    }
+                    //else if (!ImGui.IsPopupOpen($"{GUIAlarm.GUI_ID}##{tTempGUI_Key}"))
+                    //{
+                    //    GUIAlarm.ResetPopup();
+                    //}
                 }
                 else
                 {
@@ -97,25 +111,27 @@ namespace BozjaBuddy.GUI.Sections
                                                         MidpointRounding.ToNegativeInfinity
                                                         )
                                                     )
-                                                .ToString(@"mm\:ss")))
-                        && !ImGui.IsPopupOpen($"{GUIAlarm.GUI_ID}##{tTempGUI_Key}"))
+                                                .ToString(@"mm\:ss"))))
                     {
-                        GUIAlarm.CreatePopupCreateAlarm(tTempGUI_Key);
-                    }
-                    else if (!ImGui.IsPopupOpen($"{GUIAlarm.GUI_ID}##{tTempGUI_Key}"))
-                    {
-                        GUIAlarm.ResetPopup();
+                        GUIAlarm.CreateACPU(
+                            tTempGUI_Key, 
+                            pNameSuggestion: $"{AlarmWeather.kReprString} {Alarm.GetIdCounter()} | {tWeather.Item1.GetName()} | {WeatherBarSection._mTerritories[pTerritoryId]}");
                     }
                 }
                 ImGui.PopStyleVar();
                 ImGui.PopStyleVar();
-                GUIAlarm.DrawPopupCreateAlarm<AlarmWeather>(this.mPlugin, tTempGUI_Key, tWeather.Item1.Id, $"{AlarmWeather.kReprString} | {tWeather.Item1.GetName()} | {WeatherBarSection._mTerritories[pTerritoryId]}");
+                GUIAlarm.DrawACPU_Weather(
+                                            this.mPlugin, 
+                                            tTempGUI_Key, 
+                                            tWeather.Item1.Id, 
+                                            pTerritoryId,
+                                            tProcessedTime);
                 ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 0);
                 ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0, ImGui.GetStyle().ItemSpacing[1]));
                 ImGui.PopStyleColor();
                 if (ImGui.IsItemHovered())
                 {
-                    ImGui.SetTooltip($"{tWeather.Item1.GetName()}:\nin {Math.Round((tWeather.Item2 - DateTime.UtcNow).TotalMinutes)} mins\nat {DateTime.UtcNow.AddSeconds(Math.Round((tWeather.Item2 - DateTime.UtcNow).TotalSeconds, MidpointRounding.ToNegativeInfinity)).ToLocalTime().ToLongTimeString()}");
+                    ImGui.SetTooltip($"{tWeather.Item1.GetName()}:\nin {Math.Round((tWeather.Item2 - DateTime.UtcNow).TotalMinutes)} mins\nat {tProcessedTime.ToLongTimeString()}");
                 }
             }
             ImGui.PopStyleVar();
@@ -132,6 +148,11 @@ namespace BozjaBuddy.GUI.Sections
         {
             WeatherBarSection._updateWeatherCurr(pPlugin, pTerritoryId);
             return WeatherBarSection._mForeCast[pTerritoryId][0];
+        }
+        public static (FFXIVWeather.Models.Weather, DateTime) GetWeatherNext(Plugin? pPlugin, string pTerritoryId, bool pUpdateWeather = true, bool pUpdateWeatherAll = false)
+        {
+            if (pPlugin != null && pUpdateWeather) WeatherBarSection._updateWeatherCurr(pPlugin, pTerritoryId);
+            return WeatherBarSection._mForeCast[pTerritoryId][1];
         }
         public static List<(FFXIVWeather.Models.Weather, DateTime)> GetForecast(Plugin pPlugin, string pTerritoryId)
         {
@@ -152,14 +173,52 @@ namespace BozjaBuddy.GUI.Sections
         }
         public static void _updateWeatherCurr(Plugin pPlugin, string pTerritoryId)
         {
+            // first forecast
             if (!WeatherBarSection._mForeCast.ContainsKey(pTerritoryId))
-                WeatherBarSection._updateForecast(pPlugin, pTerritoryId);
-
-            // refresh forecast only if the second weather has neg delta
-            if (Math.Round((WeatherBarSection._mForeCast[pTerritoryId][1].Item2 - DateTime.UtcNow).TotalMinutes) < 0)
             {
                 WeatherBarSection._updateForecast(pPlugin, pTerritoryId);
+                // Notify AlarmManager's listener
+                WeatherBarSection._NotifyAlarmListener(pTerritoryId);
             }
+
+            // refresh forecast only if the second weather has neg delta
+            if (Math.Round((WeatherBarSection._mForeCast[pTerritoryId][1].Item2 - DateTime.UtcNow).TotalSeconds) < 0)
+            {
+                WeatherBarSection._updateForecast(pPlugin, pTerritoryId);
+                // Notify AlarmManager's listener
+                WeatherBarSection._NotifyAlarmListener(pTerritoryId);
+            }
+        }
+        public static void _updateWeatherCurr(Plugin pPlugin)
+        {
+            foreach (string iTerritoryId in WeatherBarSection._mTerritories.Keys)
+            {
+                WeatherBarSection._updateWeatherCurr(pPlugin, iTerritoryId);
+            }
+        }
+        private static void _NotifyAlarmListener(string pTerritoryId)
+        {
+            if (WeatherBarSection._mForeCast[pTerritoryId].Count < 2) return;
+            if (!AlarmManager.Listeners.ContainsKey("weather"))
+            {
+                AlarmManager.Listeners.Add("weather", new List<MsgAlarm>());
+            }
+            if (AlarmManager.Listeners["weather"].Count >= 2)
+            {
+                AlarmManager.Listeners["weather"].Clear();
+            }
+            AlarmManager.Listeners["weather"].Add(new MsgAlarmWeather(pTerritoryId, WeatherBarSection._mForeCast[pTerritoryId][0].Item1.Id));
+            
+            // weatherSequel listener is for peeking into the next weather
+            if (!AlarmManager.Listeners.ContainsKey("weatherSequel"))
+            {
+                AlarmManager.Listeners.Add("weatherSequel", new List<MsgAlarm>());
+            }
+            if (AlarmManager.Listeners["weatherSequel"].Count >= 2)
+            {
+                AlarmManager.Listeners["weatherSequel"].Clear();
+            }
+            AlarmManager.Listeners["weatherSequel"].Add(new MsgAlarmWeather(pTerritoryId, WeatherBarSection._mForeCast[pTerritoryId][1].Item1.Id));
         }
 
         public override void Dispose()

--- a/BozjaBuddy/Plugin.cs
+++ b/BozjaBuddy/Plugin.cs
@@ -56,11 +56,13 @@ namespace BozjaBuddy
             this.DATA_PATHS["loadout.json"] = Path.Combine(tDir, @"db\loadout.json");
             this.DATA_PATHS["loadout_preset.json"] = Path.Combine(tDir, @"db\loadout_preset.json");
             this.DATA_PATHS["alarm_audio"] = Path.Combine(tDir, @"db\audio\epicsaxguy.mp3");
+            this.DATA_PATHS["alarm.json"] = Path.Combine(tDir, @"db\alarm.json");
 
             mBBDataManager = new BBDataManager(this);
             mBBDataManager.SetUpAuxiliary();
             WindowSystem.AddWindow(new ConfigWindow(this));
             WindowSystem.AddWindow(new MainWindow(this));
+            WindowSystem.AddWindow(new AlarmWindow(this));
 
             this.CommandManager.AddHandler(CommandName, new CommandInfo(OnCommand)
             {
@@ -94,7 +96,7 @@ namespace BozjaBuddy
 
         public void DrawConfigUI()
         {
-            WindowSystem.GetWindow("Bozja Buddy Config")!.IsOpen = true;
+            WindowSystem.GetWindow("Config - BozjaBuddy")!.IsOpen = true;
         }
     }
 }

--- a/BozjaBuddy/Plugin.cs
+++ b/BozjaBuddy/Plugin.cs
@@ -33,7 +33,7 @@ namespace BozjaBuddy
 
         public Configuration Configuration { get; init; }
         public WindowSystem WindowSystem = new("Bozja Buddy");
-        public AlarmManager Alarm { get; init; }
+        public AlarmManager AlarmManager { get; init; }
 
         public Plugin(
             [RequiredVersion("1.0")] DalamudPluginInterface pluginInterface,
@@ -70,15 +70,15 @@ namespace BozjaBuddy
             this.PluginInterface.UiBuilder.Draw += DrawUI;
             this.PluginInterface.UiBuilder.OpenConfigUi += DrawConfigUI;
 
-            this.Alarm = new AlarmManager(this);
-            this.Alarm.Start();
+            this.AlarmManager = new AlarmManager(this);
+            this.AlarmManager.Start();
         }
 
         public void Dispose()
         {
             this.WindowSystem.RemoveAllWindows();
             this.CommandManager.RemoveHandler(CommandName);
-            this.Alarm.Dispose();
+            this.AlarmManager.Dispose();
         }
 
         private void OnCommand(string command, string args)

--- a/BozjaBuddy/Utils/Utils.cs
+++ b/BozjaBuddy/Utils/Utils.cs
@@ -23,5 +23,13 @@ namespace BozjaBuddy.Utils
         {
             return pNum > 999 ? $"{pNum / 1000}k" : pNum.ToString();
         }
+        public static DateTime ProcessToLocalTime(DateTime pDateTime)
+        {
+            return DateTime.UtcNow.AddSeconds(Math.Round((pDateTime - DateTime.UtcNow).TotalSeconds, MidpointRounding.ToNegativeInfinity)).ToLocalTime();
+        }
+        public static Vector4 RGBAtoVec4(int R, int G, int B, int A)
+        {
+            return new Vector4((float)R / 255, (float)G / 255, (float)B / 255, (float)A / 255);
+        }
     }
 }

--- a/BozjaBuddy/Utils/UtilsGUI.cs
+++ b/BozjaBuddy/Utils/UtilsGUI.cs
@@ -1,0 +1,29 @@
+﻿using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BozjaBuddy.Utils
+{
+    internal class UtilsGUI
+    {
+        // https://www.programcreek.com/cpp/?code=kswaldemar%2Frewind-viewer%2Frewind-viewer-master%2Fsrc%2Fimgui_impl%2Fimgui_widgets.cpp
+        public static void ShowHelpMarker(string desc, string markerText = "(?)", bool disabled = true)
+        {
+            if (disabled)
+                ImGui.TextDisabled(markerText);
+            else
+                ImGui.TextUnformatted(markerText);
+
+            if (!ImGui.IsItemHovered()) return;
+
+            ImGui.BeginTooltip();
+            ImGui.PushTextWrapPos(450.0f);
+            ImGui.TextUnformatted(desc);
+            ImGui.PopTextWrapPos();
+            ImGui.EndTooltip();
+        }
+    }
+}

--- a/BozjaBuddy/Utils/UtilsGUI.cs
+++ b/BozjaBuddy/Utils/UtilsGUI.cs
@@ -1,7 +1,6 @@
-﻿using ImGuiNET;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using Dalamud.Interface.Colors;
+using ImGuiNET;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -9,6 +8,7 @@ namespace BozjaBuddy.Utils
 {
     internal class UtilsGUI
     {
+        
         // https://www.programcreek.com/cpp/?code=kswaldemar%2Frewind-viewer%2Frewind-viewer-master%2Fsrc%2Fimgui_impl%2Fimgui_widgets.cpp
         public static void ShowHelpMarker(string desc, string markerText = "(?)", bool disabled = true)
         {
@@ -16,14 +16,34 @@ namespace BozjaBuddy.Utils
                 ImGui.TextDisabled(markerText);
             else
                 ImGui.TextUnformatted(markerText);
-
+            UtilsGUI.SetTooltipForLastItem(desc);
+        }
+        public static void SetTooltipForLastItem(string tDesc, float tSize = 450.0f)
+        {
             if (!ImGui.IsItemHovered()) return;
 
             ImGui.BeginTooltip();
-            ImGui.PushTextWrapPos(450.0f);
-            ImGui.TextUnformatted(desc);
+            ImGui.PushTextWrapPos(tSize);
+            ImGui.TextUnformatted(tDesc);
             ImGui.PopTextWrapPos();
             ImGui.EndTooltip();
+        }
+        public static void TextWithHelpMarker(string pText, string pHelpMarkerText = "", Vector4? pColor = null)
+        {
+            if (pColor != null)
+                ImGui.TextColored(pColor.Value, pText);
+            else
+                ImGui.Text(pText);
+            ImGui.SameLine(); UtilsGUI.ShowHelpMarker(pHelpMarkerText);
+        }
+        
+        internal class Colors
+        {
+            public static Vector4 NormalText_White = ImGuiColors.DalamudWhite2;
+            public static Vector4 BackgroundText_Grey = ImGuiColors.ParsedGrey;
+            public static Vector4 ActivatedText_Green = ImGuiColors.ParsedGreen;
+            public static Vector4 NormalBar_Grey = Utils.RGBAtoVec4(165, 165, 165, 80);
+            public static Vector4 ActivatedBar_Green = Utils.RGBAtoVec4(176, 240, 6, 80);
         }
     }
 }

--- a/BozjaBuddy/Windows/AlarmWindow.cs
+++ b/BozjaBuddy/Windows/AlarmWindow.cs
@@ -1,0 +1,297 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Xml.Serialization;
+using BozjaBuddy.Data.Alarm;
+using BozjaBuddy.GUI;
+using BozjaBuddy.GUI.Sections;
+using BozjaBuddy.Utils;
+using Dalamud.Interface.Colors;
+using Dalamud.Interface.Components;
+using Dalamud.Interface.Style;
+using Dalamud.Interface.Windowing;
+using Dalamud.Logging;
+using ImGuiNET;
+
+namespace BozjaBuddy.Windows
+{
+    internal class AlarmWindow : Window, IDisposable
+    {
+        private Plugin Plugin;
+        private bool mIsCollapseHeaderTopActive = false;
+        private bool mIsCollapseHeaderBottomActive = false;
+
+        public AlarmWindow(Plugin plugin) : base("Alarm - BozjaBuddy", ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
+        {
+            this.SizeConstraints = new WindowSizeConstraints
+            {
+                MinimumSize = new Vector2(211, 220),
+                MaximumSize = new Vector2(float.MaxValue, float.MaxValue)
+            };
+            this.Plugin = plugin;
+        }
+
+        public override void Draw()
+        {
+            // Menu bar
+            UtilsGUI.ShowHelpMarker($"- Alarm overview: \r\n+ Time-based: alarms which trigger at a specific time. Can only be created in Alarm window.\r\n+ Weather-based: alarms which trigger at a specific weather at a specific time (ONCE), or every time the weather occurs (REPEAT). Can be created in Alarm window, or clicking on Weather bar.\r\n+ FATE-based: alarms which trigger every time a FATE occurs (CEs not yet supported). Can be created in Alarm window, or click on Alarm column in Fate/CE table.\r\n- Alarm can be turned off, edited, deleted, or recycled once expire.");
+            ImGui.SameLine(); AlarmWindow.DrawAlarmNotificationBar(this.Plugin, "alarmWindow", pPadding: (float)2.5);
+            ImGui.SameLine(); AuxiliaryViewerSection.GUIAlignRight(1);
+            string tTempGUI_Key = "alarmWin";
+            if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Plus))
+            {
+                GUIAlarm.CreateACPU(tTempGUI_Key, pNameSuggestion: Alarm.kReprString);
+            }
+            GUIAlarm.DrawACPU_All(
+                            this.Plugin,
+                            tTempGUI_Key);
+
+            // Alarm List: Alive
+            if (ImGui.CollapsingHeader($"Alarms ({this.Plugin.AlarmManager.GetAlarms().Count})", ImGuiTreeNodeFlags.DefaultOpen))
+            {
+                this.mIsCollapseHeaderTopActive = true;
+                ImGui.PushStyleVar(ImGuiStyleVar.ChildRounding, 5.0f);
+                ImGui.BeginChild("alarmList_alive",
+                    new System.Numerics.Vector2(
+                        ImGui.GetWindowWidth() - ImGui.GetStyle().FramePadding.X * 4, 
+                        ImGui.GetWindowHeight() / (this.mIsCollapseHeaderBottomActive ? 2 : 1) - ImGui.GetCursorPosY() - (this.mIsCollapseHeaderBottomActive ? 0 : ImGui.GetStyle().FramePadding.Y * 11)),
+                    true);
+
+                List<Alarm> tAlarmsToRemove = new();
+                foreach (Alarm iAlarm in this.Plugin.AlarmManager.GetAlarms())
+                {
+                    // BUTTON
+                    ImGui.PushID(iAlarm.mId);
+                    ImGui.BeginGroup();
+                    // power
+                    ImGui.PushStyleColor(ImGuiCol.Text, iAlarm.mIsAwake
+                                                        ? ImGuiColors.DalamudWhite2
+                                                        : Utils.Utils.RGBAtoVec4(0, 0, 0, 100));
+                    if (ImGuiComponents.IconButton(
+                            Dalamud.Interface.FontAwesomeIcon.PowerOff, 
+                            defaultColor: Utils.Utils.RGBAtoVec4(165, 165, 165, 80)
+                            ))
+                    {
+                        if (iAlarm.mIsAwake)
+                        {
+                            this.Plugin.AlarmManager.SleepAlarm(iAlarm);
+                        }
+                        else
+                        {
+                            this.Plugin.AlarmManager.WakeAlarm(iAlarm);
+                        }
+                    }
+                    UtilsGUI.SetTooltipForLastItem("Turn alarm on/off. Turned-off alarms will not be triggered until they're on again.");
+                    ImGui.PopStyleColor();
+                    // edit
+                    string tTempGUI_Key2 = "aEdit";
+                    if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.PenSquare))
+                    {
+                        GUIAlarm.CreateACPU(tTempGUI_Key2, iAlarm);
+                    }
+                    switch (iAlarm)
+                    {
+                        case AlarmTime:
+                            GUIAlarm.DrawACPU_Time(
+                                this.Plugin, 
+                                tTempGUI_Key2, 
+                                pTriggerTime: iAlarm.mTriggerTime,
+                                pAlarmToEdit: iAlarm);
+                            break;
+                        case AlarmWeather:
+                            GUIAlarm.DrawACPU_Weather(
+                                this.Plugin,
+                                tTempGUI_Key2,
+                                iAlarm.mTriggerInt ?? 0,
+                                iAlarm.mTriggerString,
+                                iAlarm.mTriggerTime,
+                                pAlarmToEdit: iAlarm);
+                            break;
+                        case AlarmFateCe:
+                            GUIAlarm.DrawACPU_FateCe(
+                                this.Plugin,
+                                tTempGUI_Key2,
+                                iAlarm.mTriggerInt ?? 0,
+                                pAlarmToEdit: iAlarm);
+                            break;
+                    }
+                    // delete
+                    if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Trash))
+                    {
+                        tAlarmsToRemove.Add(iAlarm);
+                    }
+                    UtilsGUI.SetTooltipForLastItem("Permanently delete alarm. (NOT moving to expired list)");
+                    ImGui.EndGroup();
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+
+                    // TEXT
+                    ImGui.BeginGroup();
+                    this.DrawAlarmInfo(iAlarm);
+                    ImGui.EndGroup();
+
+                    ImGui.Separator();
+                }
+                foreach (Alarm iAlarm in tAlarmsToRemove)
+                {
+                    this.Plugin.AlarmManager.RemoveAlarm(iAlarm);
+                }
+
+                ImGui.EndChild();
+                ImGui.PopStyleVar();
+            }
+            else
+            {
+                this.mIsCollapseHeaderTopActive = false;
+            }
+
+            // Alarm List: Disposed
+            if (ImGui.CollapsingHeader($"Expired Alarms ({this.Plugin.AlarmManager.GetDisposedAlarms().Count})"))
+            {
+                this.mIsCollapseHeaderBottomActive = true;
+                ImGui.PushStyleVar(ImGuiStyleVar.ChildRounding, 5.0f);
+                ImGui.BeginChild("alarmList_disposed",
+                    new System.Numerics.Vector2(
+                        ImGui.GetWindowWidth() - ImGui.GetStyle().FramePadding.X * 4,
+                        ImGui.GetWindowHeight() / (this.mIsCollapseHeaderTopActive ? 2 : 1) - ImGui.GetCursorPosY() - (this.mIsCollapseHeaderTopActive ? 0 : ImGui.GetStyle().FramePadding.Y * 11)),
+                    true);
+
+                List<Alarm> tAlarmsToRemove = new();
+                List<Alarm> tAlarmsToUnexpire = new();
+                foreach (Alarm iAlarm in this.Plugin.AlarmManager.GetDisposedAlarms())
+                {
+                    // BUTTON
+                    ImGui.PushID(iAlarm.mId);
+                    ImGui.BeginGroup();
+
+                    if (iAlarm.GetType() == typeof(AlarmTime)) ImGui.BeginDisabled();
+                    // recycle
+                    if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Recycle))
+                    {
+                        tAlarmsToUnexpire.Add(iAlarm);
+                    }
+                    if (iAlarm.GetType() == typeof(AlarmTime)) ImGui.EndDisabled();
+                    UtilsGUI.SetTooltipForLastItem("Un-expired this alarm with the same setting. (not applicable for Time Alarm)");
+                    // trash
+                    if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Trash))
+                    {
+                        tAlarmsToRemove.Add(iAlarm);
+                    }
+                    UtilsGUI.SetTooltipForLastItem("Permanently delete alarm.");
+                    ImGui.EndGroup();
+                    ImGui.PopID();
+
+                    ImGui.SameLine();
+
+                    // TEXT
+                    ImGui.BeginGroup();
+                    this.DrawAlarmInfo(iAlarm);
+                    ImGui.EndGroup();
+
+                    ImGui.Separator();
+                }
+                foreach (Alarm iAlarm in tAlarmsToRemove)
+                {
+                    this.Plugin.AlarmManager.RemoveAlarm(iAlarm);
+                }
+                foreach (Alarm iAlarm in tAlarmsToUnexpire)
+                {
+                    this.Plugin.AlarmManager.UnexpireAlarm(iAlarm);
+                }
+
+                ImGui.EndChild();
+                ImGui.PopStyleVar();
+            }
+            else
+            {
+                this.mIsCollapseHeaderBottomActive = false;
+            }
+        }
+        private void DrawAlarmInfo(Alarm pAlarm, bool pIsExpired = false)
+        {
+            ImGui.PushTextWrapPos();
+            // Name
+            if (pIsExpired)
+            {
+                ImGui.Text(pAlarm.mName);
+            }
+            else
+            {
+                ImGui.TextColored(!pAlarm.mIsAlive
+                        ? UtilsGUI.Colors.ActivatedText_Green
+                        : UtilsGUI.Colors.NormalText_White,
+                   pAlarm.mName);
+            }
+            // Desc
+            try
+            {
+                ImGui.TextColored(UtilsGUI.Colors.BackgroundText_Grey, String.Format("{0}",
+                                                            pAlarm._mJsonId switch
+                                                            {
+                                                                AlarmTime._kJsonid => $"Time",
+                                                                AlarmWeather._kJsonid => $"Weather | {WeatherBarSection._mTerritories[pAlarm.mTriggerString!]} | {WeatherBarSection._mWeatherNames[pAlarm.mTriggerInt!.Value]}",
+                                                                AlarmFateCe._kJsonid => $"Fate/Ce | {this.Plugin.mBBDataManager.mFates[pAlarm.mTriggerInt!.Value].mName}",
+                                                                _ => "unknown"
+                                                            }));
+                ImGui.TextColored(UtilsGUI.Colors.BackgroundText_Grey, String.Format("{0}{1}{2}",
+                                                            pAlarm.mIsRevivable ? "Repeat" : "Once",
+                                                            $" | ±{pAlarm.mOffset}s",
+                                                            !pAlarm.mIsRevivable && pAlarm.mTriggerTime.HasValue
+                                                                ? $" | {pAlarm.mTriggerTime}"
+                                                                : ""
+                                                            ));
+            }
+            catch (KeyNotFoundException)
+            {
+                ImGui.TextColored(UtilsGUI.Colors.BackgroundText_Grey, $"Corrupted alarm data. (trgStr={pAlarm.mTriggerString} trgInt={pAlarm.mTriggerInt})");
+            }
+            ImGui.PopTextWrapPos();
+        }
+        public static void DrawAlarmNotificationBar(Plugin pPlugin, string pGUIId, bool pIsStretching = true, float pWidth = 300, float pPadding = 1)
+        {
+            ImGui.PushID(pGUIId);
+            ImGui.PushStyleColor(
+                ImGuiCol.Button,
+                pPlugin.AlarmManager.GetDurationLeft() > 0
+                    ? UtilsGUI.Colors.ActivatedBar_Green
+                    : UtilsGUI.Colors.NormalBar_Grey
+                );
+            if (ImGui.Button(
+                pPlugin.AlarmManager.GetDurationLeft() > 0
+                    ? pPlugin.AlarmManager.GetMuteStatus()
+                        ? $"Alarm! Sound muted. ({pPlugin.AlarmManager.GetDurationLeft()}s)"
+                        : $"Alarm! Click to mute. ({pPlugin.AlarmManager.GetDurationLeft()}s)"
+                    : pPlugin.AlarmManager.GetAAAAlarmCount() > 0
+                        ? $"{pPlugin.AlarmManager.GetAAAAlarmCount()} alarms running..."
+                        : "---------",
+                new Vector2(
+                    (pIsStretching
+                            ? ImGui.GetWindowWidth()
+                            : pWidth)
+                        - ImGui.GetStyle().WindowPadding.X * 2 - (ImGui.GetFontSize() * pPadding + ImGui.GetStyle().FramePadding.X * 2) - ImGui.GetStyle().ItemInnerSpacing.X,
+                    ImGui.GetTextLineHeight() + ImGui.GetStyle().FramePadding.Y * 2 - ImGui.GetStyle().ItemInnerSpacing.Y / 2))
+                && pPlugin.AlarmManager.GetTriggerStatus())
+            {
+                pPlugin.AlarmManager.MuteSound();
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.PushTextWrapPos(200);
+                ImGui.TextUnformatted("Alarm notification bar.");
+                ImGui.PopTextWrapPos();
+                ImGui.EndTooltip();
+            }
+            ImGui.PopStyleColor();
+            ImGui.PopID();
+        }
+        private void DrawAlarmGUI(Alarm pAlarm)
+        {
+
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/BozjaBuddy/Windows/ConfigWindow.cs
+++ b/BozjaBuddy/Windows/ConfigWindow.cs
@@ -10,7 +10,7 @@ public class ConfigWindow : Window, IDisposable
     private Configuration Configuration;
 
     public ConfigWindow(Plugin plugin) : base(
-        "Bozja Buddy Config",
+        "Config - BozjaBuddy",
         ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar |
         ImGuiWindowFlags.NoScrollWithMouse )
     {

--- a/BozjaBuddy/Windows/MainWindow.cs
+++ b/BozjaBuddy/Windows/MainWindow.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Dalamud.Interface.Windowing;
 using ImGuiNET;
 using BozjaBuddy.GUI.Tabs;
+using BozjaBuddy.GUI.Sections;
 
 namespace BozjaBuddy.Windows;
 
@@ -13,6 +14,7 @@ public class MainWindow : Window, IDisposable
     private FateCeTab mFateCeTab;
     private MobTab mMobTab;
     private LoadoutTab mLoadoutTab;
+    private GeneralSection mGeneralSection;
  
     public MainWindow(Plugin plugin) : base(
         "Bozja Buddy", ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
@@ -28,6 +30,7 @@ public class MainWindow : Window, IDisposable
         this.mFateCeTab = new FateCeTab(this.Plugin);
         this.mMobTab = new MobTab(this.Plugin);
         this.mLoadoutTab = new LoadoutTab(this.Plugin);
+        this.mGeneralSection = new GeneralSection(this.Plugin);
     }
 
     public void Dispose()
@@ -40,6 +43,7 @@ public class MainWindow : Window, IDisposable
 
     public override void Draw()
     {
+        this.mGeneralSection.DrawGUI();
         if (ImGui.BeginTabBar("Tab Bat")) {
             this.mLostActionTab.DrawGUI();
             this.mFateCeTab.DrawGUI();


### PR DESCRIPTION
- Added Alarm for Bozja content.
- Added a general options bar, with a button to open Alarm window, and a button to shut the alarm up.
- Fix a bug in Extra information tab where FATE-chain would not show up in FATE extra info.
---
- Alarm overview: 
+ Time-based: alarms which trigger at a specific time. Can only be created in Alarm window.
+ Weather-based: alarms which trigger at a specific weather at a specific time (ONCE), or every time the weather occurs (REPEAT). Can be created in Alarm window, or clicking on Weather bar.
+ FATE-based: alarms which trigger every time a FATE occurs (CEs not yet supported). Can be created in Alarm window, or click on Alarm column in Fate/CE table.
- Alarm can be turned off, edited, deleted, or recycled once expire.