### PR TITLE
0.3.4.3 Bug fixes. Alternative layout.

### DIFF
--- a/BozjaBuddy/BozjaBuddy.csproj
+++ b/BozjaBuddy/BozjaBuddy.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>0.3.4.2</Version>
+    <Version>0.3.4.3</Version>
     <Description>A sample plugin.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/goatcorp/SamplePlugin</PackageProjectUrl>

--- a/BozjaBuddy/Configuration.cs
+++ b/BozjaBuddy/Configuration.cs
@@ -53,6 +53,7 @@ namespace BozjaBuddy
         public bool mIsInGridMode_FieldNoteTableSection = true;
         public bool mIsInGridMode_LostActionTableSection = true;
         public bool mIsAroVisible_LostActionTableSection = true;
+        public bool mIsAuxiFocused = false;
         public HashSet<int> mCacheAlertIgnoreIds = new();
         public HashSet<int> mUserFieldNotes = new();
 

--- a/BozjaBuddy/GUI/GuiScraper.cs
+++ b/BozjaBuddy/GUI/GuiScraper.cs
@@ -143,7 +143,7 @@ namespace BozjaBuddy.GUI
                         : Marshal.PtrToStringAnsi((IntPtr)texFileNameStdString->BufferPtr);
                     if (texString == null) continue;
 
-                    if (texString == "ui/icon/072000/072576_hr1.tex")
+                    if (texString == "ui/icon/072000/072576_hr1.tex" || texString == "ui/icon/072000/072608_hr1.tex")
                         tUserFieldNotes.Remove((id - 7) + ((tCurrPage - 1) * 10));
                     else 
                         tUserFieldNotes.Add((id - 7) + ((tCurrPage - 1) * 10));

--- a/BozjaBuddy/GUI/Sections/AuxiliaryViewerSection.cs
+++ b/BozjaBuddy/GUI/Sections/AuxiliaryViewerSection.cs
@@ -64,6 +64,7 @@ namespace BozjaBuddy.GUI.Sections
                                                                     : ImGuiTabItemFlags.None))
             {
                 if (pObj.GetGenId() == AuxiliaryViewerSection._mGenIdToTabFocus) AuxiliaryViewerSection._mGenIdToTabFocus = -1;   // Release selected
+                ImGui.BeginChild($"##{pObj.mId}", new Vector2(ImGui.GetWindowWidth(), 390));
                 if (pObj is Loadout)
                 {
                     this.DrawTabHeaderLoadout(pObj);
@@ -79,6 +80,8 @@ namespace BozjaBuddy.GUI.Sections
                     this.DrawTabHeader(pObj);
                     this.DrawTabContent(pObj);
                 }
+                ImGui.Separator();
+                ImGui.EndChild();
                 ImGui.EndTabItem();
             }
             if (pObj.mTabColor != null) ImGui.PopStyleColor();
@@ -291,6 +294,19 @@ namespace BozjaBuddy.GUI.Sections
                 if (ImGui.BeginMenuBar())
                 {
                     ImGui.TextColored(tLoadout.mWeight > 99 ? UtilsGUI.Colors.NormalText_Red : UtilsGUI.Colors.BackgroundText_Grey, $"WEIGHT: {tLoadout.mWeight} / 99");
+                    ImGui.SameLine();
+                    // Lost action grid popup
+                    //ImGui.SetCursorPos(new Vector2(ImGui.GetCursorPosX() + (ImGui.GetWindowWidth() / 5 * 2 + 10), 0));
+                    AuxiliaryViewerSection.GUIAlignRight(-5);
+                    if (ImGui.Button(" + "))
+                    {
+                        ImGui.OpenPopup("##lagrid");
+                    }
+                    if (ImGui.BeginPopup("##lagrid"))
+                    {
+                        this.mLostActionTableSection.DrawTable_GridOnly();
+                        ImGui.EndPopup();
+                    }
                     ImGui.EndMenuBar();
                 }
                 UtilsGUI.InputPayload tInputPayload = new();

--- a/BozjaBuddy/GUI/Sections/GeneralSection.cs
+++ b/BozjaBuddy/GUI/Sections/GeneralSection.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using Dalamud.Interface.Components;
 using System.Runtime.CompilerServices;
 using System.Data;
+using Dalamud.Interface.Colors;
 
 namespace BozjaBuddy.GUI.Sections
 {
@@ -49,8 +50,21 @@ namespace BozjaBuddy.GUI.Sections
             // Search all box
             string tSearchVal = this.mGuiVars["searchAll"];
             ImGui.SameLine();
-            GeneralSection.DrawSearchAllBox(this.mPlugin, ref tSearchVal);
+            GeneralSection.DrawSearchAllBox(this.mPlugin, ref tSearchVal, pTextBoxWidth: ImGui.GetContentRegionAvail().X - 27);
             this.mGuiVars["searchAll"] = tSearchVal;
+            // Section switch button
+            ImGui.SameLine();
+            if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.ArrowsUpDown, defaultColor: this.mPlugin.Configuration.mIsAuxiFocused
+                                                                                                         ? UtilsGUI.Colors.MycItemBoxOverlay_Red
+                                                                                                         : null))
+            {
+                this.mPlugin.Configuration.mIsAuxiFocused = !this.mPlugin.Configuration.mIsAuxiFocused;
+                this.mPlugin.MainWindow.RearrangeSection();
+            }
+            else
+            {
+                UtilsGUI.SetTooltipForLastItem($"Alternative layout: {(this.mPlugin.Configuration.mIsAuxiFocused ? "ON" : "OFF")}\n- Bring the information viewer to the top.\n\n(can be toggled by pressing [Alt] while this plugin window is being focused)");
+            }
 
             return true;
         }

--- a/BozjaBuddy/GUI/Sections/LostActionTableSection.cs
+++ b/BozjaBuddy/GUI/Sections/LostActionTableSection.cs
@@ -384,11 +384,18 @@ namespace BozjaBuddy.GUI.Sections
                 ImGui.SameLine();
             }
 
-            AuxiliaryViewerSection.GUIAlignRight("Compact mode      [GRID]");
-            ImGui.TextColored(UtilsGUI.Colors.BackgroundText_Grey, "Compact mode");
-            ImGui.SameLine();
-            ImGuiComponents.ToggleButton("comTog", ref this.mIsCompactModeActive);
-            ImGui.SameLine();
+            if (!this.mPlugin.Configuration.mIsInGridMode_LostActionTableSection)
+            {
+                AuxiliaryViewerSection.GUIAlignRight("Compact mode      [GRID]");
+                ImGui.TextColored(UtilsGUI.Colors.BackgroundText_Grey, "Compact mode");
+                ImGui.SameLine();
+                ImGuiComponents.ToggleButton("comTog", ref this.mIsCompactModeActive);
+                ImGui.SameLine();
+            }
+            else
+            {
+                AuxiliaryViewerSection.GUIAlignRight(-1);
+            }
             if (ImGuiComponents.IconButton(this.mPlugin.Configuration.mIsInGridMode_LostActionTableSection
                              ? FontAwesomeIcon.GripHorizontal
                              : FontAwesomeIcon.List))

--- a/BozjaBuddy/GUI/Tab.cs
+++ b/BozjaBuddy/GUI/Tab.cs
@@ -2,6 +2,7 @@ using ImGuiNET;
 using BozjaBuddy.Interface;
 using System.Collections.Generic;
 using BozjaBuddy.Utils;
+using BozjaBuddy.GUI.Sections;
 
 namespace BozjaBuddy.GUI
 {
@@ -12,8 +13,42 @@ namespace BozjaBuddy.GUI
     {
         protected abstract string mName { get; set; }
         protected abstract Dictionary<int, Section> mSortedSections { get; set; }
+        protected abstract Dictionary<int, Section> mSortedSections_Default { get; set; }
         protected abstract Plugin mPlugin { get; set; }
 
+        /// <summary>
+        /// Do not create new Section. Find and put front Auxi section by default
+        /// </summary>
+        public virtual void RearrangeSection()
+        {
+            if (this.mPlugin.Configuration.mIsAuxiFocused)
+            {
+                if (this.mSortedSections.Count < 2) return;
+
+                Dictionary<int, Section> tRes = new();
+                int tResKey = 1; // save 0 idx for focused Section
+                Section? tFocusedSection = null;
+                foreach (var iKey in mSortedSections.Keys)
+                {
+                    if (mSortedSections[iKey] is AuxiliaryViewerSection)
+                    {
+                        tFocusedSection = mSortedSections[iKey];
+                    }
+                    else
+                    {
+                        tRes[tResKey] = mSortedSections[iKey];
+                        tResKey++;
+                    }
+                }
+                if (tFocusedSection == null) { return; }
+                tRes.Add(0, tFocusedSection);
+                this.mSortedSections = tRes;
+            }
+            else if (this.mSortedSections_Default != null)
+            {
+                this.mSortedSections = this.mSortedSections_Default;
+            }
+        }
         
         public virtual bool DrawGUI()
         {

--- a/BozjaBuddy/GUI/Tabs/FateCeTab.cs
+++ b/BozjaBuddy/GUI/Tabs/FateCeTab.cs
@@ -9,6 +9,7 @@ namespace BozjaBuddy.GUI.Tabs
     {
         protected override string mName { get; set; }
         protected override Dictionary<int, Section> mSortedSections { get; set; }
+        protected override Dictionary<int, Section> mSortedSections_Default { get; set; }
         protected override Plugin mPlugin { get; set; }
         public FateCeTab(Plugin pPlugin)
         {
@@ -19,6 +20,7 @@ namespace BozjaBuddy.GUI.Tabs
                 { 1, new FateCeTableSection(this.mPlugin) },
                 { 2, new AuxiliaryViewerSection(this.mPlugin) }
             };
+            this.mSortedSections_Default = this.mSortedSections;
         }
         public override bool DrawGUI()
         {

--- a/BozjaBuddy/GUI/Tabs/FieldNoteTab.cs
+++ b/BozjaBuddy/GUI/Tabs/FieldNoteTab.cs
@@ -11,6 +11,7 @@ namespace BozjaBuddy.GUI.Tabs
     {
         protected override string mName { get; set; }
         protected override Dictionary<int, Section> mSortedSections { get; set; }
+        protected override Dictionary<int, Section> mSortedSections_Default { get; set; }
         protected override Plugin mPlugin { get; set; }
 
         public FieldNoteTab(Plugin pPlugin)
@@ -21,6 +22,7 @@ namespace BozjaBuddy.GUI.Tabs
                 { 0, new FieldNoteTableSection(this.mPlugin) },
                 { 1, new AuxiliaryViewerSection(this.mPlugin) }
             };
+            this.mSortedSections_Default = this.mSortedSections;
         }
 
         public void Dispose()

--- a/BozjaBuddy/GUI/Tabs/LoadoutTab.cs
+++ b/BozjaBuddy/GUI/Tabs/LoadoutTab.cs
@@ -8,6 +8,7 @@ namespace BozjaBuddy.GUI.Tabs
     {
         protected override string mName { get; set; }
         protected override Dictionary<int, Section> mSortedSections { get; set; }
+        protected override Dictionary<int, Section> mSortedSections_Default { get; set; }
         protected override Plugin mPlugin { get; set; }
 
         public LoadoutTab(Plugin pPlugin)
@@ -19,6 +20,7 @@ namespace BozjaBuddy.GUI.Tabs
                 { 0, new LoadoutTableSection(this.mPlugin) },
                 { 1, new AuxiliaryViewerSection(this.mPlugin) }
             };
+            this.mSortedSections_Default = this.mSortedSections;
         }
 
         public void Dispose()

--- a/BozjaBuddy/GUI/Tabs/LostActionTab.cs
+++ b/BozjaBuddy/GUI/Tabs/LostActionTab.cs
@@ -11,6 +11,7 @@ namespace BozjaBuddy.GUI.Tabs
     {
         protected override string mName { get; set; }
         protected override Dictionary<int, Section> mSortedSections { get; set; }
+        protected override Dictionary<int, Section> mSortedSections_Default { get; set; }
         protected override Plugin mPlugin { get; set; }
 
         public LostActionTab(Plugin pPlugin)
@@ -21,6 +22,7 @@ namespace BozjaBuddy.GUI.Tabs
                 { 0, new LostActionTableSection(this.mPlugin) },
                 { 1, new AuxiliaryViewerSection(this.mPlugin) }
             };
+            this.mSortedSections_Default = this.mSortedSections;
         }
 
         public void Dispose()

--- a/BozjaBuddy/GUI/Tabs/MobTab.cs
+++ b/BozjaBuddy/GUI/Tabs/MobTab.cs
@@ -8,6 +8,7 @@ namespace BozjaBuddy.GUI.Tabs
     {
         protected override string mName { get; set; }
         protected override Dictionary<int, Section> mSortedSections { get; set; }
+        protected override Dictionary<int, Section> mSortedSections_Default { get; set; }
         protected override Plugin mPlugin { get; set; }
         public MobTab(Plugin pPlugin)
         {
@@ -18,6 +19,7 @@ namespace BozjaBuddy.GUI.Tabs
                 { 1, new MobTableSection(this.mPlugin) },
                 { 2, new AuxiliaryViewerSection(this.mPlugin) }
             };
+            this.mSortedSections_Default = this.mSortedSections;
         }
 
         public void Dispose()

--- a/BozjaBuddy/Plugin.cs
+++ b/BozjaBuddy/Plugin.cs
@@ -45,6 +45,7 @@ namespace BozjaBuddy
         public AlarmManager AlarmManager { get; init; }
         public GuiScraper GuiScraper { get; init; }
         public GUIAssistManager GUIAssistManager { get; init; }
+        public MainWindow MainWindow { get; init; }
 
         public Plugin(
             [RequiredVersion("1.0")] DalamudPluginInterface pluginInterface,
@@ -80,8 +81,9 @@ namespace BozjaBuddy
 
             mBBDataManager = new BBDataManager(this);
             UtilsGameData.Init(this);
+            this.MainWindow = new(this);
             WindowSystem.AddWindow(new ConfigWindow(this));
-            WindowSystem.AddWindow(new MainWindow(this));
+            WindowSystem.AddWindow(this.MainWindow);
             WindowSystem.AddWindow(new AlarmWindow(this));
             WindowSystem.AddWindow(new CharStatsWindow(this));
 
@@ -112,6 +114,8 @@ namespace BozjaBuddy
 
             this.PluginInterface.UiBuilder.BuildFonts += this.BuildFont;
             this.PluginInterface.UiBuilder.RebuildFonts();
+
+            this.MainWindow.RearrangeSection();
         }
         
         private void BuildFont()

--- a/BozjaBuddy/Utils/UtilsGUI.cs
+++ b/BozjaBuddy/Utils/UtilsGUI.cs
@@ -656,8 +656,11 @@ namespace BozjaBuddy.Utils
         public class InputPayload
         {
             private static DateTime kLastMouseClicked = DateTime.MinValue;
+            private static DateTime kLastKeyClicked = DateTime.MinValue;
             private const double kMouseClickValidityThreshold = 150;
+            private const double kKeyClickValidityThreshold = 250;
             private static double DeltaLastMouseClick() => (DateTime.Now - InputPayload.kLastMouseClicked).TotalMilliseconds;
+            private static double DeltaLastKeyClick() => (DateTime.Now - InputPayload.kLastKeyClicked).TotalMilliseconds;
             public static bool CheckMouseClickValidity()
             {
                 if (InputPayload.DeltaLastMouseClick() > kMouseClickValidityThreshold)
@@ -667,16 +670,27 @@ namespace BozjaBuddy.Utils
                 }
                 return false;
             }
+            public static bool CheckKeyClickValidity()
+            {
+                if (InputPayload.DeltaLastKeyClick() > kKeyClickValidityThreshold)
+                {
+                    InputPayload.kLastKeyClicked = DateTime.Now;
+                    return true;
+                }
+                return false;
+            }
 
             public bool mIsHovered = false;
             public bool mIsMouseRmb = false;
             public bool mIsMouseLmb = false;
             public bool mIsKeyShift = false;
+            public bool mIsKeyAlt = false;
 
             public void CaptureInput()
             {
                 var io = ImGui.GetIO();
                 if (io.KeyShift) mIsKeyShift = true;
+                if (io.KeyAlt) mIsKeyAlt = true;
                 if (io.MouseReleased[0]) mIsMouseLmb = true;
                 if (io.MouseReleased[1]) mIsMouseRmb = true;
             }

--- a/BozjaBuddy/Windows/MainWindow.cs
+++ b/BozjaBuddy/Windows/MainWindow.cs
@@ -4,6 +4,7 @@ using Dalamud.Interface.Windowing;
 using ImGuiNET;
 using BozjaBuddy.GUI.Tabs;
 using BozjaBuddy.GUI.Sections;
+using BozjaBuddy.Utils;
 
 namespace BozjaBuddy.Windows;
 
@@ -32,6 +33,14 @@ public class MainWindow : Window, IDisposable
         this.mFieldNoteTab = new FieldNoteTab(this.Plugin);
     }
 
+    public void RearrangeSection()
+    {
+        this.mLostActionTab.RearrangeSection();
+        this.mFateCeTab.RearrangeSection();
+        this.mMobTab.RearrangeSection();
+        this.mLoadoutTab.RearrangeSection();
+        this.mFieldNoteTab.RearrangeSection();
+    }
     public void Dispose()
     {
         this.mLostActionTab.Dispose();
@@ -43,6 +52,13 @@ public class MainWindow : Window, IDisposable
 
     public override void Draw()
     {
+        if (ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows)
+            && ImGui.GetIO().KeyAlt
+            && UtilsGUI.InputPayload.CheckKeyClickValidity())
+        {
+            this.Plugin.Configuration.mIsAuxiFocused = !this.Plugin.Configuration.mIsAuxiFocused;
+            this.Plugin.MainWindow.RearrangeSection();
+        }
         this.mGeneralSection.DrawGUI();
         if (ImGui.BeginTabBar("Tab Bat")) {
             this.mLostActionTab.DrawGUI();


### PR DESCRIPTION
Bozja Buddy 0.3.4.3
- Added Alternative layouts to the main window.
- Added a button to toggle alternative layout. Can also be toggled by pressing key [Alt] while plugin main window is focused.

- Fix a bug where the Field note updates doesn't work properly.
- In Loadout edit, added a ` + ` button on the holster title bar, on the right - which pops up the Lost action grid when clicked.