### PR TITLE
0.3.4.4 Auto role-filter. Helper. Lost Find Cache bug fix.

### DIFF
--- a/BozjaBuddy/BozjaBuddy.csproj
+++ b/BozjaBuddy/BozjaBuddy.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>0.3.4.3</Version>
+    <Version>0.3.4.4</Version>
     <Description>A sample plugin.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/goatcorp/SamplePlugin</PackageProjectUrl>

--- a/BozjaBuddy/BozjaBuddy.json
+++ b/BozjaBuddy/BozjaBuddy.json
@@ -14,5 +14,6 @@
         "fragment",
         "relic",
         "alarm"
-    ]
+    ],
+    "AcceptsFeedback":  true
 }

--- a/BozjaBuddy/Configuration.cs
+++ b/BozjaBuddy/Configuration.cs
@@ -222,6 +222,7 @@ namespace BozjaBuddy
                 public bool isDisabled_LoadoutMiniview = false;
                 public bool isDisabled_FilterText = false;
                 public bool isDisabled_FilterLoadout = false;
+                public bool isDisabled_AutoRoleFilter = false;
 
                 public float refreshRate = 0.3f;
                 public int filterTextLevel = 1;

--- a/BozjaBuddy/Filter/LostActionTableSection/FilterRole.cs
+++ b/BozjaBuddy/Filter/LostActionTableSection/FilterRole.cs
@@ -55,6 +55,10 @@ namespace BozjaBuddy.Filter.LostActionTableSection
                 ImGui.EndPopup();
             }
         }
+        public void SetCurrValue(RoleFlag pRoleFlag)
+        {
+            this.mCurrValue = pRoleFlag;
+        }
 
         public override string GetCurrValue()
         {

--- a/BozjaBuddy/GUI/GUIAssist/GUIAssistManager.cs
+++ b/BozjaBuddy/GUI/GUIAssist/GUIAssistManager.cs
@@ -41,6 +41,8 @@ namespace BozjaBuddy.GUI.GUIAssist
         private ExtGui_MycInfo mExtGui_MycInfo;
         private HashSet<int> _MycItemBagTrade_ValidNodeIds = new HashSet<int>(new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
 
+        private bool mHasAppliedAutoroleFilter = false;
+
         private GUIAssistManager() { }
         public GUIAssistManager(Plugin pPlugin) 
         {
@@ -219,6 +221,21 @@ namespace BozjaBuddy.GUI.GUIAssist
             unsafe
             {
                 var tAddonMycItemBox = (AtkUnitBase*)this.mPlugin.GameGui.GetAddonByName("MYCItemBox");
+                if (tAddonMycItemBox == null)
+                {
+                    this.mHasAppliedAutoroleFilter = false;
+                }
+                else
+                {
+                    if (!this.mHasAppliedAutoroleFilter
+                        && !this.mPlugin.Configuration.mGuiAssistConfig.itemBox.isDisabled_AutoRoleFilter)
+                    {
+                        RoleFlag tUserRole = new();
+                        tUserRole.SetRoleFlagBit(UtilsGameData.GetUserRole(this.mPlugin) ?? Role.None);
+                        this.mExtGui_MycItemBox.mFilterRole.SetCurrValue(tUserRole);
+                        this.mHasAppliedAutoroleFilter = true;
+                    }
+                }
 
                 // Update user's Cache and Holster saved info (only when the Box is opened, and every 1 sec)
                 if (tAddonMycItemBox != null && (DateTime.Now - this._cycle3).TotalSeconds > this.mPlugin.Configuration.mGuiAssistConfig.itemBox.refreshRate)
@@ -370,10 +387,31 @@ break;
                                     }
                                 }
                             }
-                            else if (tLoadout == null && tIsFilteredIn)
+                            else if (tLoadout == null)
                             {
-                                this.ShowNode(iLostAction.mUINode);
-                                this.UnfadeNode(iLostAction.mUINode); 
+                                if (tIsFilteredIn)
+                                {
+                                    this.ShowNode(iLostAction.mUINode);
+                                    this.UnfadeNode(iLostAction.mUINode);
+                                }
+                                else
+                                {
+                                    switch (tTextFilterLevel)
+                                    {
+                                        case 0:
+                                            this.ShowNode(iLostAction.mUINode);
+                                            this.UnfadeNode(iLostAction.mUINode);
+                                            break;
+                                        case 1:
+                                            this.ShowNode(iLostAction.mUINode);
+                                            this.FadeNode(iLostAction.mUINode);
+                                            break;
+                                        case 2:
+                                            this.HideNode(iLostAction.mUINode);
+                                            break;
+                                        default: break;
+                                    }
+                                }
                             }
                         }
                     }

--- a/BozjaBuddy/GUI/GUIExtension/ExtGui_MycItemBox.cs
+++ b/BozjaBuddy/GUI/GUIExtension/ExtGui_MycItemBox.cs
@@ -132,7 +132,7 @@ namespace BozjaBuddy.GUI.GUIExtension
 
                 ImGui.SameLine();
                 ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new System.Numerics.Vector2(0, 0));
-                this.mFilterRole.DrawFilterGUI();
+                this.mFilterRole.DrawFilterGUI(); 
                 ImGui.PopStyleVar();
 
                 tAnchor1 = ImGui.GetCursorScreenPos();

--- a/BozjaBuddy/GUI/GuiScraper.cs
+++ b/BozjaBuddy/GUI/GuiScraper.cs
@@ -143,7 +143,10 @@ namespace BozjaBuddy.GUI
                         : Marshal.PtrToStringAnsi((IntPtr)texFileNameStdString->BufferPtr);
                     if (texString == null) continue;
 
-                    if (texString == "ui/icon/072000/072576_hr1.tex" || texString == "ui/icon/072000/072608_hr1.tex")
+                    if (texString == "ui/icon/072000/072576_hr1.tex"
+                        || texString == "ui/icon/072000/072576.tex"
+                        || texString == "ui/icon/072000/072608_hr1.tex"
+                        || texString == "ui/icon/072000/072608.tex")
                         tUserFieldNotes.Remove((id - 7) + ((tCurrPage - 1) * 10));
                     else 
                         tUserFieldNotes.Add((id - 7) + ((tCurrPage - 1) * 10));

--- a/BozjaBuddy/GUI/Sections/GeneralSection.cs
+++ b/BozjaBuddy/GUI/Sections/GeneralSection.cs
@@ -11,6 +11,7 @@ using Dalamud.Interface.Components;
 using System.Runtime.CompilerServices;
 using System.Data;
 using Dalamud.Interface.Colors;
+using System.Linq;
 
 namespace BozjaBuddy.GUI.Sections
 {
@@ -50,8 +51,23 @@ namespace BozjaBuddy.GUI.Sections
             // Search all box
             string tSearchVal = this.mGuiVars["searchAll"];
             ImGui.SameLine();
-            GeneralSection.DrawSearchAllBox(this.mPlugin, ref tSearchVal, pTextBoxWidth: ImGui.GetContentRegionAvail().X - 27);
+            GeneralSection.DrawSearchAllBox(this.mPlugin, ref tSearchVal, pTextBoxWidth: ImGui.GetContentRegionAvail().X - 52);
             this.mGuiVars["searchAll"] = tSearchVal;
+            // Help button
+            ImGui.SameLine();
+            if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.Question))
+            {
+                ImGui.OpenPopup("##helperpu");
+            }
+            else
+            {
+                UtilsGUI.SetTooltipForLastItem("Keybinds\n\n1. [Alt] to toggle alternative layout while plugin's main window is focused.\n2. With a link (hinted by symbol »):\n- Hover for quick info.\n- [LMB] to open link in info viewer section at the bottom.\n- [RMB] to see more options (marketboard, location, alarm, etc.).\n- For action's icon link, [Shift+LMB/RMB] will add the selected action to the currently edited Custom Loadout.");
+            }
+            if (ImGui.BeginPopup("##helperpu", ImGuiWindowFlags.NoResize))
+            {
+                GeneralSection.DrawHelper(this.mPlugin);
+                ImGui.EndPopup();
+            }
             // Section switch button
             ImGui.SameLine();
             if (ImGuiComponents.IconButton(Dalamud.Interface.FontAwesomeIcon.ArrowsUpDown, defaultColor: this.mPlugin.Configuration.mIsAuxiFocused
@@ -124,6 +140,48 @@ namespace BozjaBuddy.GUI.Sections
                     ImGui.EndPopup();
                 }
             }
+        }
+        private static void DrawHelper(Plugin pPlugin)
+        {
+            if (!ImGui.BeginTabBar("##helpertb")) return;
+            
+            // Tab: General
+            if (ImGui.BeginTabItem("General"))
+            {
+                ImGui.BeginChild("##hw", new Vector2(500, 200));
+                ImGui.PushTextWrapPos();
+                ImGui.Text("1. Any website or communities mentioned in this plugin are not sponsored or affiliated with the author in anyway.");
+                ImGui.Separator();
+                ImGui.Text("2. Any issues related to ownership or validity of community-created content, such as Recommended loadouts; please let us know and we may edited/removed accordingly.");
+                ImGui.Separator();
+                ImGui.Text("3. The plugin is designed with convenience in mind. However, if anything feels intrusive to you, feel free to let us know.");
+                ImGui.Separator();
+                ImGui.Text("4. The plugin will not have any automatical or braindead functionality (e.g. solve mechanics you, etc.)");
+                ImGui.Separator();
+                ImGui.Text("5. Technical issues can be sent through normal feedback function. Suggestions/inquiries please forward to XIVLauncher's discord > Plugin-help-forum > Bozja-buddy.");
+                ImGui.PopTextWrapPos();
+                ImGui.EndChild();
+                ImGui.EndTabItem();
+            }
+            // Tab: Keybinds
+            if (ImGui.BeginTabItem("Keybinds"))
+            {
+                ImGui.BeginChild("##hw", new Vector2(500, 200));
+                ImGui.PushTextWrapPos();
+                ImGui.Text("1. [Alt] to toggle alternative layout while plugin's main window is focused.");
+                ImGui.Separator();
+                ImGui.Text("2. With a link (hinted by symbol » like");
+                ImGui.SameLine();
+                UtilsGUI.SelectableLink_WithPopup(pPlugin, "this", pPlugin.mBBDataManager.mLostActions.First().Value.GetGenId());
+                ImGui.SameLine();
+                ImGui.Text("):");
+                ImGui.Text("- Hover for quick info.\n- [LMB] to open link in info viewer section at the bottom.\n- [RMB] to see available options (marketboard, location, alarm, etc.).\n- For action's icon link, [Shift+LMB/RMB] will add the selected action to the currently edited Custom Loadout.");
+                ImGui.PopTextWrapPos();
+                ImGui.EndChild();
+                ImGui.EndTabItem();
+            }
+
+            ImGui.EndTabBar();
         }
         public unsafe void DrawActionCount()
         {

--- a/BozjaBuddy/Utils/UtilsGameData.cs
+++ b/BozjaBuddy/Utils/UtilsGameData.cs
@@ -163,7 +163,7 @@ namespace BozjaBuddy.Utils
             {
                 1 => Role.Tank,
                 2 => Role.Melee,
-                3 => tJob.GameData!.JobIndex == 2 ? Role.Range : Role.Caster,
+                3 => tJob.GameData!.PrimaryStat == 2 ? Role.Range : Role.Caster,
                 4 => Role.Healer,
                 _ => ~tRole,
             };

--- a/BozjaBuddy/Windows/ConfigWindow.cs
+++ b/BozjaBuddy/Windows/ConfigWindow.cs
@@ -528,6 +528,20 @@ public class ConfigWindow : Window, IDisposable
         ImGui.SameLine();
         ImGui.SetCursorPosX(ImGui.GetCursorPosX() + tInnerSpacing);
         UtilsGUI.ShowHelpMarker($"Refresh rate is the rate at which the UI is updated.\nLower value yields better user experience at the cost of potential game stuttering. And vice versa.\n The default value ({pPlugin.Configuration.mGuiAssistConfig.itemBox.refreshRateDefault}) is recommended.");
+
+        // Auto-role Filter
+        bool tTemp7 = !pPlugin.Configuration.mGuiAssistConfig.itemBox.isDisabled_AutoRoleFilter;
+        if (ImGuiComponents.ToggleButton("tg_7", ref tTemp7))
+        {
+            pPlugin.Configuration.mGuiAssistConfig.itemBox.isDisabled_AutoRoleFilter = !tTemp7;
+            pPlugin.Configuration.Save();
+        }
+        ImGui.SameLine();
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + tInnerSpacing);
+        UtilsGUI.TextDescriptionForWidget("7. Auto Role-filter.");
+        ImGui.SameLine();
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + tInnerSpacing);
+        UtilsGUI.ShowHelpMarker($"Automatically apply your current role to the Lost Find Cahe every time you open it.\nDoes not clear the filter when disabled.");
     }
     public static void Draw_LoadoutPairingButton(Plugin pPlugin, Dictionary<string, ImGuiTextFilterPtr> pGuiVar_TextFilters)
     {


### PR DESCRIPTION
Bozja Buddy 0.3.4.4
- Added a Lost Find Cache filter option [7] to allow auto role-filter based on player's current role.
- Added a helper button on the top bar of the main window. Hovering shows keybinds, clicking shows a helper popup.

- Fix a bug where the text filter for Lost Find Cache does not work as intended when user does not have an Active Loadout.