### PR TITLE
Fix Imgui style potentially breaking on plugin load

### DIFF
--- a/BozjaBuddy/Plugin.cs
+++ b/BozjaBuddy/Plugin.cs
@@ -114,9 +114,6 @@ namespace BozjaBuddy
                 HelpMessage = "Open the main menu"
             }); 
 
-            this.PluginInterface.UiBuilder.Draw += DrawUI;
-            this.PluginInterface.UiBuilder.OpenConfigUi += DrawConfigUI;
-
             this.AlarmManager = new AlarmManager(this);
             this.AlarmManager.Start();
 
@@ -124,6 +121,9 @@ namespace BozjaBuddy
             this.Framework.Update += this.OnUpdate;
 
             this.GUIAssistManager = new(this);
+
+            this.PluginInterface.UiBuilder.Draw += DrawUI;
+            this.PluginInterface.UiBuilder.OpenConfigUi += DrawConfigUI;
 
             if (this.Configuration.UserLoadouts == null) { this.mBBDataManager.ReloadLoadoutsPreset(); }    // for first install
             this.Configuration.SizeConstraints = new()      // overwrite on-disk config's size constraint


### PR DESCRIPTION
The ordering here resulted in DrawUI sometimes being called when GUIAssistManager was still null. Resulting in an excption and the default Dalamud style being broken