### PR TITLE
Update to API 14

### DIFF
--- a/BozjaBuddy/BozjaBuddy.csproj
+++ b/BozjaBuddy/BozjaBuddy.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/13.1.0">
+<Project Sdk="Dalamud.NET.Sdk/14.0.1">
   <PropertyGroup>
     <Authors>kaleidocli</Authors>
     <Company></Company>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Platforms>x64;AnyCPU</Platforms>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/BozjaBuddy/Data/BBDataManager.cs
+++ b/BozjaBuddy/Data/BBDataManager.cs
@@ -24,7 +24,7 @@ namespace BozjaBuddy.Data
         private static HashSet<int> kAllowedQuest = new();
         private static HashSet<int> kAllowedQuestGenre = new()
         {
-            76,      // Resistance weapons
+            90,      // Resistance weapons
             21,      // Return to Ivalice
             8,       // ShB
             9,       // ShB post 1
@@ -367,9 +367,9 @@ namespace BozjaBuddy.Data
             HashSet<Tuple<int, int>>? tLinkers = new();
             // Get selected quests
             HashSet<Lumina.Excel.Sheets.Quest> tQuests = this.mSheetQuest.Where(
-                                                                                        i => i.Expansion.Value.RowId == 3       // ShB
+                                                                                        i => i.Expansion.RowId == 3       // ShB
                                                                                             || (i.JournalGenre.IsValid
-                                                                                                && BBDataManager.kAllowedQuestGenre.Contains((int)i.JournalGenre.Value.RowId))
+                                                                                                && BBDataManager.kAllowedQuestGenre.Contains((int)i.JournalGenre.RowId))
                                                                                         )
                                                                                     .Select(o => o)
                                                                                     .ToHashSet();

--- a/BozjaBuddy/GUI/GuiScraper.cs
+++ b/BozjaBuddy/GUI/GuiScraper.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Dalamud.Plugin.Services;
 using static Lumina.Data.Parsing.Uld.NodeData;
 
 namespace BozjaBuddy.GUI
@@ -129,10 +130,10 @@ namespace BozjaBuddy.GUI
                 if (!int.TryParse(tNodeNoto->NodeText.ToString(), out tCharStats.noto)) tCharStats.noto = 0;
 
                 // Rays
-                if (this.mPlugin.ClientState.LocalPlayer != null)
+                if (this.mPlugin.ObjectTable.LocalPlayer != null)
                 {
                     Dictionary<int, int> tStatusList = new();
-                    foreach (Dalamud.Game.ClientState.Statuses.Status s in this.mPlugin.ClientState.LocalPlayer.StatusList)
+                    foreach (Dalamud.Game.ClientState.Statuses.IStatus s in this.mPlugin.ObjectTable.LocalPlayer.StatusList)
                     {
                         tStatusList.TryAdd((int)s.StatusId, (int)s.Param);
                     }

--- a/BozjaBuddy/Plugin.cs
+++ b/BozjaBuddy/Plugin.cs
@@ -64,6 +64,8 @@ namespace BozjaBuddy
         public IFramework Framework { get; init; }
 
         public IUiBuilder UIBuilder { get; set; }
+        
+        public IObjectTable ObjectTable { get; init; }
 
         public Plugin(
             IDalamudPluginInterface pluginInterface,
@@ -76,7 +78,8 @@ namespace BozjaBuddy
             IKeyState keyState,
             IFramework framework,
             ITextureProvider textureProvider,
-            IPluginLog pLog)
+            IPluginLog pLog,
+            IObjectTable objectTable)
         {
             this.PluginInterface = pluginInterface;
             this.CommandManager = commandManager;
@@ -91,6 +94,7 @@ namespace BozjaBuddy
             this.UIBuilder = this.PluginInterface.UiBuilder;
             PluginLog = pLog;
             this.PLog = pLog;
+            this.ObjectTable = objectTable;
             
 
             string tDir = PluginInterface.AssemblyLocation.DirectoryName!;

--- a/BozjaBuddy/packages.lock.json
+++ b/BozjaBuddy/packages.lock.json
@@ -1,18 +1,18 @@
 {
   "version": 1,
   "dependencies": {
-    "net9.0-windows7.0": {
+    "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[13.1.0, )",
-        "resolved": "13.1.0",
-        "contentHash": "XdoNhJGyFby5M/sdcRhnc5xTop9PHy+H50PTWpzLhJugjB19EDBiHD/AsiDF66RETM+0qKUdJBZrNuebn7qswQ=="
+        "requested": "[14.0.1, )",
+        "resolved": "14.0.1",
+        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[1.2.25, )",
-        "resolved": "1.2.25",
-        "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
+        "requested": "[1.2.39, )",
+        "resolved": "1.2.39",
+        "contentHash": "fcFN01tDTIQqDuTwr1jUQK/geofiwjG5DycJQOnC72i1SsLAk1ELe+apBOuZ11UMQG8YKFZG1FgvjZPbqHyatg=="
       },
       "FFXIVWeather": {
         "type": "Direct",
@@ -68,31 +68,16 @@
         "resolved": "6.4.4",
         "contentHash": "yj1+/4tci7Panu3jKDHYizxwVm0Jvm7b7m057b5h4u8NUHGCR8WIWirBTw+8EptRffwftIWPBeIRGNKD1ewEMQ==",
         "dependencies": {
-          "Microsoft.CSharp": "4.7.0",
           "System.CodeDom": "4.7.0",
           "System.ComponentModel.Annotations": "4.7.0",
           "System.Configuration.ConfigurationManager": "4.7.0",
           "System.Data.SqlClient": "4.8.1"
         }
       },
-      "Microsoft.CSharp": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
-      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "3.1.0",
         "contentHash": "z7aeg8oHln2CuNulfhiLYxCVMPEwBl3rzicjvIX+4sUuCwvXw5oXQEtbiU2c0z4qYL5L3Kmx0mMA/+t/SbY67w=="
-      },
-      "Microsoft.Win32.Registry": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "KSrRMb5vNi0CWSGG1++id2ZOs/1QhRqROt+qgbEAdQuGjGrFcl4AOl4/exGPUYz2wUnU42nvJqon1T3U0kPXLA==",
-        "dependencies": {
-          "System.Security.AccessControl": "4.7.0",
-          "System.Security.Principal.Windows": "4.7.0"
-        }
       },
       "Microsoft.Win32.SystemEvents": {
         "type": "Transitive",
@@ -161,8 +146,6 @@
         "resolved": "4.8.1",
         "contentHash": "HKLykcv6eZLbLnSMnlQ6Os4+UAmFE+AgYm92CTvJYeTOBtOYusX3qu8OoGhFrnKZax91UcLcDo5vPrqvJUTSNQ==",
         "dependencies": {
-          "Microsoft.Win32.Registry": "4.7.0",
-          "System.Security.Principal.Windows": "4.7.0",
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
       },
@@ -183,15 +166,6 @@
           "Microsoft.Win32.SystemEvents": "4.7.0"
         }
       },
-      "System.Security.AccessControl": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "JECvTt5aFF3WT3gHpfofL2MNNP6v84sxtXxpqhLBCcDRzqsPBmHhQ6shv4DwwN2tRlzsUxtb3G9M3763rbXKDg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "3.1.0",
-          "System.Security.Principal.Windows": "4.7.0"
-        }
-      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
         "resolved": "4.7.0",
@@ -202,14 +176,8 @@
         "resolved": "4.7.0",
         "contentHash": "dkOV6YYVBnYRa15/yv004eCGRBVADXw8qRbbNiCn/XpdJSUXkkUeIvdvFHkvnko4CdKMqG8yRHC4ox83LSlMsQ==",
         "dependencies": {
-          "System.Security.AccessControl": "4.7.0",
           "System.Windows.Extensions": "4.7.0"
         }
-      },
-      "System.Security.Principal.Windows": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "ojD0PX0XhneCsUbAZVKdb7h/70vyYMDYs85lwEI+LngEONe/17A0cFaRFqZU+sOEidcVswYWikYOQ9PPfjlbtQ=="
       },
       "System.Windows.Extensions": {
         "type": "Transitive",


### PR DESCRIPTION
this Updates the Plugin to SDK 14 including all the relevant changes

im not sure why the JournalGenre RowID for the Resistance Weapons change from 76 to 90, but without that it wouldnt grab the Quests
[JournalGenre#R90 on EXD Viewer](https://exd.camora.dev/sheet/JournalGenre#R90)
also dropping the .Value, because Lumina was exploding loading the Referenced Row in that LINQ Query

and LocalPlayer moved from ClientState to ObjectTable